### PR TITLE
Fixing console formatting

### DIFF
--- a/source/includes/Concepts/concept.md
+++ b/source/includes/Concepts/concept.md
@@ -66,11 +66,17 @@ referenced source.
 
 ## List concepts
 
-* ### List all concepts.
-    
+### List all concepts.
+
+```console
+GET /concept?
+  term=38341003
+  &source=SNOMED%20CT
+```
+
     Quickly filter concepts with given query parameters. Returns a `404 Not Found` status if concepts not exist. If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
     
-    #### Query Parameters
+### Query Parameters
 
     Parameter | Type | Description
     --- | --- | ---
@@ -81,22 +87,33 @@ referenced source.
     *source* | `String` | A concept can have any number of mappings to any number of other vocabularies. Other vocabularies are called "concept sources" in OpenMRS (ie. LOINC, SNOMED, ICD-9, ICD10, RxNORM, etc), but the concept source can also be a custom (ie. org.openmrs.module.mdrtb, PIH, AMPATH, MVP, etc.). Every concept can define a string for its mapping in any "concept source" defined in the database
     *class* | `String` | The concept's class provides a useful way to narrow down the scope of the information that the concept is intended to capture.  In this way, the class is helpful for data extraction.  This classification elaborates how a concept will be represented (i.e. as a question or an answer) when the information is stored.  OpenMRS contains several default classes to use when defining concepts, but implementation sites may also create additional custom concept classes.
     
-```console
-GET /concept?
-  term=38341003
-  &source=SNOMED%20CT
- ```
     
-* ### Query concept by UUID.
+### Query concept by UUID.
 
-    Retrieve a concept by its UUID. Returns a `404 Not Found` status if concepts not exist. If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
-    
 ```console
 GET /concept/:target_concept_uuid
 ```
+    Retrieve a concept by its UUID. Returns a `404 Not Found` status if concepts not exist. If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
+    
    
 ## Create a concept
 
+```console
+POST /concept
+{
+  "names": [
+    {
+      "name": "What is the blood type for the patient?",
+      "locale": "en",
+      "localePreferred": true,
+      "conceptNameType": "FULLY_SPECIFIED"
+    }
+  ],
+  "datatype": "8d4a4c94-c2cc-11de-8d13-0010c6dffd0f",
+  "version": "1.2.2",
+  "conceptClass": "8d492774-c2cc-11de-8d13-0010c6dffd0f"
+}
+```
 * To Create a concept, you need to specify below attributes in the request body. If you are not logged in to perform this action,
  a `401 Unauthorized` status returned.
 
@@ -115,12 +132,15 @@ GET /concept/:target_concept_uuid
     *descriptions* | `Array[] String` | A concept map connects a concept term to a concept
     *mappings* | `Array[] String` | Connects a concept term to a concept.  
    
+
+## Update a concept
+
 ```console
-POST /concept
+POST /concept/:target_concept_uuid
 {
   "names": [
     {
-      "name": "What is the blood type for the patient?",
+      "name": "What is the blood type for the sick patient?",
       "locale": "en",
       "localePreferred": true,
       "conceptNameType": "FULLY_SPECIFIED"
@@ -131,8 +151,6 @@ POST /concept
   "conceptClass": "8d492774-c2cc-11de-8d13-0010c6dffd0f"
 }
 ```
-## Update a concept
-
 *  Update a target concept with given UUID, this method only modifies properties in the request. Returns a `404 Not Found` 
 status if concept not exists. If the user is not logged in to perform this action, a `401 Unauthorized` status is returned.
     
@@ -151,25 +169,12 @@ status if concept not exists. If the user is not logged in to perform this actio
     *descriptions* | `Array[] String` | A concept map connects a concept term to a concept
     *mappings* | `Array[] String` | Connects a concept term to a concept.  
 
-```console
-POST /concept/:target_concept_uuid
-{
-  "names": [
-    {
-      "name": "What is the blood type for the sick patient?",
-      "locale": "en",
-      "localePreferred": true,
-      "conceptNameType": "FULLY_SPECIFIED"
-    }
-  ],
-  "datatype": "8d4a4c94-c2cc-11de-8d13-0010c6dffd0f",
-  "version": "1.2.2",
-  "conceptClass": "8d492774-c2cc-11de-8d13-0010c6dffd0f"
-}
-```
     
 ## Delete a concept
 
+```console
+DELETE /concept/:target_concept_uuid?purge=true
+```
 * Delete or retire a target concept by its UUID. Returns a `404 Not Found` status if concept not exists. If the user is not logged 
   in to perform this action, a `401 Unauthorized` status returned.
 
@@ -179,30 +184,34 @@ POST /concept/:target_concept_uuid
     --- | --- | ---
     *purge* | `Boolean` | The resource will be retired unless purge = ‘true’
 
-```console
-DELETE /concept/:target_concept_uuid?purge=true
-```
 ## List concept mapping
 
-* ### List all concept mappings for a concept.
-
-    Retrieve all **concept mapping** subresources of a **concept** resource by target_concept_uuid. Returns a 
-    `404 Not Found` status if concept mapping not exists. If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
+### List all concept mappings for a concept.
 
 ```console
 GET /concept/:target_concept_uuid/mapping 
 ```
+    Retrieve all **concept mapping** subresources of a **concept** resource by target_concept_uuid. Returns a 
+    `404 Not Found` status if concept mapping not exists. If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
 
-* ### List concept mapping by its UUID and parent concept UUID.
-    
-     Retrieve a **concept mapping** subresources of a **concept** resource. Returns a 
-     `404 Not Found` status if concept mapping not exists. If you are not logged in to perform this action, a `401 Unauthorized` status returned.
-     
+
+### List concept mapping by its UUID and parent concept UUID.
+
 ```console
 GET /concept/:target_concept_uuid/mapping/:target_concept_mapping_uuid
 ```
+         Retrieve a **concept mapping** subresources of a **concept** resource. Returns a 
+     `404 Not Found` status if concept mapping not exists. If you are not logged in to perform this action, a `401 Unauthorized` status returned.
+     
 ## Create a concept mapping with properties
 
+```console
+POST concept/:target_concept_uuid/mapping
+{
+  "conceptReferenceTerm": "21fb14d7-5cd9-3621-ac30-c9e57320e233",
+  "conceptMapType": "35543629-7d8c-11e1-909d-c80aa9edcf4e"
+}
+```
 * To Create a concept mapping subresource for a specific concept resource, you need to specify below attributes in the request body.
 If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
 
@@ -213,6 +222,10 @@ Parameter | Type | Description
 *conceptReferenceTerm* | `target_concept_reference_term_type_uuid` | A concept term defines a medical coding term or OpenMRS concept dictionary term that could be mapped to a concept (required)
 *conceptMapType* | `target_concept_map_type_uuid` | A concept map connects a concept term to a concept (required)
     
+ 
+ 
+## Update a concept mapping
+
 ```console
 POST concept/:target_concept_uuid/mapping
 {
@@ -220,9 +233,6 @@ POST concept/:target_concept_uuid/mapping
   "conceptMapType": "35543629-7d8c-11e1-909d-c80aa9edcf4e"
 }
 ```
- 
- 
-## Update a concept mapping
 
 * Updates a concept mapping subresource value with given UUID, this method will only modify the value of the subresource. Returns a `404 Not Found` status if concept mapping not exists. If the user is not logged in to perform this action, a `401 Unauthorized` status
 returned.
@@ -234,48 +244,50 @@ Parameter | Type | Description
 *conceptReferenceTerm* | `target_concept_reference_term_type_uuid` | A concept term defines a medical coding term or OpenMRS concept dictionary term that could be mapped to a concept (required)
 *conceptMapType* | `target_concept_map_type_uuid` | A concept map connects a concept term to a concept (required)
 
-```console
-POST concept/:target_concept_uuid/mapping
-{
-  "conceptReferenceTerm": "21fb14d7-5cd9-3621-ac30-c9e57320e233",
-  "conceptMapType": "35543629-7d8c-11e1-909d-c80aa9edcf4e"
-}
-```
 ## Delete a concept mapping
 
+```console
+DELETE concept/:target_concept_uuid/mapping/:target_concept_mapping_uuid
+```
 * Delete or Voided a target concept mapping subresource by its UUID. Returns a `404 Not Found` status if concept mapping not exists. 
  If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
 
-    #### Query Parameters
+### Query Parameters
 
     Parameter | Type | Description
     --- | --- | ---
     *purge* | `Boolean` | The resource will be voided unless purge = ‘true’. Purging will attempt to remove the concept mapping type from the system irreversibly. Concept mapping types that have been used (i.e., are referenced from existing data) cannot be purged.
     
-```console
-DELETE concept/:target_concept_uuid/mapping/:target_concept_mapping_uuid
-```
 ## List concept name
 
-* ### List all concept names for a concept.
-
-    Retrieve all **concept name** subresources of a **concept** resource by target_concept_uuid. Returns a 
-    `404 Not Found` status if concept name not exists. If the user isnot logged in to perform this action, a `401 Unauthorized` status returned.
+### List all concept names for a concept.
 
 ```console
 GET /concept/:target_concept_uuid/name 
 ```
+    Retrieve all **concept name** subresources of a **concept** resource by target_concept_uuid. Returns a 
+    `404 Not Found` status if concept name not exists. If the user isnot logged in to perform this action, a `401 Unauthorized` status returned.
 
-* ### List concept name it's UUID and parent concept UUID.
-    
+
+### List concept name it's UUID and parent concept UUID.
+
+```console
+GET /concept/:target_concept_uuid/name/:target_concept_name_uuid
+```    
      Retrieve a **concept name** subresources of a **concept** resource. Returns a 
      `404 Not Found` status if concept name not exists. If you are not logged in to perform this action, a `401 Unauthorized` status returned.
      
-```console
-GET /concept/:target_concept_uuid/name/:target_concept_name_uuid
-```
 ## Create a concept name with properties
 
+```console
+POST concept/:target_concept_uuid/name
+{
+  "name": "Bronchospasm",
+  "locale": "en",
+  "localePreferred": true,
+  "conceptNameType": "FULLY_SPECIFIED"
+}
+```
 * To Create a concept name subresource for a specific concept resource, you need to specify below attributes in the request body.
 If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
 
@@ -287,7 +299,10 @@ If the user is not logged in to perform this action, a `401 Unauthorized` status
     *locale* | `String` | Language to record concept name (required)
     *localePreferred* | `String` | This is the preferred name to use within a locale.  By default, this is the fully-specified name; however, full-specified names are sometimes long and more detailed than necessary for day-to-day use.  In those cases, a synonym can be defined to be the locale-preferred name.  There can only be one preferred name within a locale.  The primary term should be the word(s) used by those who will have access to the records to prevent duplication of concept creation.
     *conceptNameType* | `String` | Type of the name to be specified.
-    
+     
+ 
+## Update concept name
+
 ```console
 POST concept/:target_concept_uuid/name
 {
@@ -297,10 +312,6 @@ POST concept/:target_concept_uuid/name
   "conceptNameType": "FULLY_SPECIFIED"
 }
 ```
- 
- 
-## Update concept name
-
 * Updates a concept name subresource value with given UUID, this method will only modify value of the subresource. Returns a `404 Not Found` status if concept name not exists. If the user is not logged in to perform this action, a `401 Unauthorized` status
 returned.
 
@@ -313,17 +324,12 @@ returned.
     *localePreferred* | `String` | This is the preferred name to use within a locale.  By default, this is the fully-specified name; however, full-specified names are sometimes long and more detailed than necessary for day-to-day use.  In those cases, a synonym can be defined to be the locale-preferred name.  There can only be one preferred name within a locale.  The primary term should be the word(s) used most often by those who will have access to the records to prevent duplicate concept creation.
     *conceptNameType* | `String` | Type of the name to be specified.
 
-```console
-POST concept/:target_concept_uuid/name
-{
-  "name": "Bronchospasm",
-  "locale": "en",
-  "localePreferred": true,
-  "conceptNameType": "FULLY_SPECIFIED"
-}
-```
+
 ## Delete concept name
 
+```console
+DELETE concept/:target_concept_uuid/name/:target_concept_name_uuid
+```
 * Delete or retire a target concept name subresource by its UUID. Returns a `404 Not Found` status if concept name not exists. 
  If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
 
@@ -333,31 +339,36 @@ POST concept/:target_concept_uuid/name
     --- | --- | ---
     *purge* | `Boolean` | The resource will be voided unless purge = ‘true’. Purging will attempt to remove the concept name type from the system irreversibly. Concept name types that have been used (i.e., are referenced from existing data) cannot be purged.
     
-```console
-DELETE concept/:target_concept_uuid/name/:target_concept_name_uuid
-```
 
 ## List concept attribute
 
-* ### List all concept attributes for a concept.
 
-    Retrieve all **concept attribute** subresources of a **concept** resource by target_concept_uuid. Returns a 
-    `404 Not Found` status if a concept attribute not exists. If the user isnot logged in to perform this action, a `401 Unauthorized` status returned.
+### List all concept attributes for a concept.
 
 ```console
 GET /concept/:target_concept_uuid/attribute 
 ```
+    Retrieve all **concept attribute** subresources of a **concept** resource by target_concept_uuid. Returns a 
+    `404 Not Found` status if a concept attribute not exists. If the user isnot logged in to perform this action, a `401 Unauthorized` status returned.
 
-* ### List concept attribute by its UUID and parent concept UUID.
-    
+
+### List concept attribute by its UUID and parent concept UUID.
+
+```console
+GET /concept/:target_concept_uuid/attribute/:target_concept_attribute_uuid
+```    
      Retrieve a **concept attribute** subresources of a **concept** resource. Returns a 
      `404 Not Found` status if a concept attribute not exists. If you are not logged in to perform this action, a `401 Unauthorized` status returned.
      
-```console
-GET /concept/:target_concept_uuid/attribute/:target_concept_attribute_uuid
-```
 ## Create a concept attribute with properties
 
+```console
+POST concept/:target_concept_uuid/attribute
+{
+  "attributeType": "target_concept_attribute_type_uuid",
+  "value": "value_for_the_attriute"
+}
+```
 * To Create a concept attribute subresource for a specific concept resource, you need to specify below attributes in the request body.
 If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
 
@@ -368,6 +379,10 @@ If the user is not logged in to perform this action, a `401 Unauthorized` status
     *attributeType* | `Attribute_Type UUID` | Create Attribute from this Concept Attribute_Type (required)
     *value* | `Depends on Attribute_Type Selected` | Value for the attribute (required)
     
+ 
+ 
+## Update concept attribute
+
 ```console
 POST concept/:target_concept_uuid/attribute
 {
@@ -375,10 +390,6 @@ POST concept/:target_concept_uuid/attribute
   "value": "value_for_the_attriute"
 }
 ```
- 
- 
-## Update concept attribute
-
 * Updates a concept attribute subresource value with given UUID, this method will only modify the value of the subresource. Returns a `404 Not Found` status if the concept attribute not exists. If the user is not logged in to perform this action, a `401 Unauthorized` status
 returned.
 
@@ -389,15 +400,11 @@ returned.
     *attributeType* | `Attribute_Type UUID` | Create Attribute from this Concept Attribute_Type (required)
     *value* | `Depends on Attribute_Type Selected` | Value for the attribute (required)
 
-```console
-POST concept/:target_concept_uuid/attribute
-{
-  "attributeType": "target_concept_attribute_type_uuid",
-  "value": "value_for_the_attriute"
-}
-```
 ## Delete concept attribute
 
+```console
+DELETE concept/:target_concept_uuid/attribute/:target_concept_attribute_uuid
+```
 * Delete or retire a target concept attribute subresource by its UUID. Returns a `404 Not Found` status if concept attribute not exists. 
  If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
 
@@ -407,31 +414,35 @@ POST concept/:target_concept_uuid/attribute
     --- | --- | ---
     *purge* | `Boolean` | The resource will be voided unless purge = ‘true’. Purging will attempt to remove the concept name type from the system irreversibly. Concept name types that have been used (i.e., are referenced from existing data) cannot be purged.
     
-```console
-DELETE concept/:target_concept_uuid/attribute/:target_concept_attribute_uuid
-```
     
 ## List concept descriptions
 
-* ### List all concept descriptions for a concept.
-
-    Retrieve all **concept description** subresources of a **concept** resource by target_concept_uuid. Returns a 
-    `404 Not Found` status if concept description not exists. If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
+### List all concept descriptions for a concept.
 
 ```console
     GET /concept/:target_concept_uuid/description 
 ```
+    Retrieve all **concept description** subresources of a **concept** resource by target_concept_uuid. Returns a 
+    `404 Not Found` status if concept description not exists. If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
 
-* ### List concept description by its UUID and parent concept UUID.
-    
-     Retrieve a **concept description** subresources of a **concept** resource. Returns a 
-     `404 Not Found` status if concept description not exists. If you are not logged in to perform this action, a `401 Unauthorized` status returned.
-     
+
+### List concept description by its UUID and parent concept UUID.
+
 ```console
 GET /concept/:target_concept_uuid/description/:target_concept_description_uuid
 ```
+     Retrieve a **concept description** subresources of a **concept** resource. Returns a 
+     `404 Not Found` status if concept description not exists. If you are not logged in to perform this action, a `401 Unauthorized` status returned.
+     
 ## Create a concept description with properties
 
+```console
+POST concept/:target_concept_uuid/description
+{
+  "description": "Pregnancy terminated by spontaneous abortion.",
+  "locale": "en"
+}
+```
 * To Create a concept description subresource for a specific concept resource you need to specify below attributes in the request body.
 If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
 
@@ -442,6 +453,10 @@ If the user is not logged in to perform this action, a `401 Unauthorized` status
     *description* | `String` | Description text to e provided for the concept (required)
     *locale* | `String` | Language description provided by (required)
     
+ 
+ 
+## Update concept description
+
 ```console
 POST concept/:target_concept_uuid/description
 {
@@ -449,10 +464,6 @@ POST concept/:target_concept_uuid/description
   "locale": "en"
 }
 ```
- 
- 
-## Update concept description
-
 * Updates a concept description subresource value with given UUID, this method will only modify the value of the subresource. Returns a `404 Not Found` status if concept description not exists. If the user is not logged in to perform this action, a `401 Unauthorized` status
 returned.
 
@@ -463,15 +474,11 @@ returned.
     *description* | `String` | Description text to e provided for the concept (required)
     *locale* | `String` | Language description provided by (required)
 
-```console
-POST concept/:target_concept_uuid/description
-{
-  "description": "Pregnancy terminated by spontaneous abortion.",
-  "locale": "en"
-}
-```
 ## Delete concept description
 
+```console
+DELETE concept/:target_concept_uuid/description/:target_concept_description_uuid
+```
 * Delete or retire a target concept description subresource by its UUID. Returns a `404 Not Found` status if concept description not exists. 
  If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
 
@@ -481,6 +488,4 @@ POST concept/:target_concept_uuid/description
     --- | --- | ---
     *purge* | `Boolean` | The resource will be voided unless purge = ‘true’. Purging will attempt to remove the concept description from the system irreversibly. Concept descriptions that have been used (i.e., are referenced from existing data) cannot be purged.
     
-```console
-DELETE concept/:target_concept_uuid/description/:target_concept_description_uuid
-```
+

--- a/source/includes/Concepts/concept_attribute_type.md
+++ b/source/includes/Concepts/concept_attribute_type.md
@@ -14,7 +14,11 @@
 
 ## List concept attribute types
 
-* ### List all non-retired concept attribute types.
+### List all non-retired concept attribute types.
+
+```console
+GET /conceptattributetype?q=time
+```
 
     Quickly filter concept attribute types with a given search query. Returns a `404 Not Found` status if concept attribute type not exists. 
     If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
@@ -25,20 +29,30 @@
     --- | --- | ---
     *q* | `String` | Full or partial display name of concept source
 
-```console
-GET /conceptattributetype?q=time
- ```
 
-* ### List concept attribute type by UUID.
-
-    Retrieve a concept attribute type by its UUID. Returns a `404 Not Found` status if concept attribute type not exists. If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
+### List concept attribute type by UUID.
 
 ```console
 GET /conceptattributetype/:target_concept_attribute_type_uuid
 ```
+    Retrieve a concept attribute type by its UUID. Returns a `404 Not Found` status if concept attribute type not exists. If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
+
 
 ## Create a concept attribute type
 
+```console
+POST /conceptattributetype
+{
+  "name": "Time Span",
+  "description": "This attribute type will record the time span for the concept",
+  "datatypeClassname": "org.openmrs.customdatatype.datatype.LongFreeTextDatatype",
+  "minOccurs": 0,
+  "maxOccurs": 1,
+  "datatypeConfig": "default",
+  "preferredHandlerClassname": "org.openmrs.web.attribute.handler.LongFreeTextTextareaHandler",
+  "handlerConfig": "dafault"
+}
+```
 * To Create a concept attribute type, you need to specify below attributes in the request body. If you are not logged in to perform this action,
   a `401 Unauthorized` status returned.
 
@@ -55,6 +69,8 @@ Parameter | Type | Description
 *datatypeConfig* | `String` | Provides ability to define custom data types configuration for OpenMRS
 *handlerConfig* | `String` | Allow handler to be used for more than one attribute type. The actual configuration depends on the needs of the specified handler. For example, a "Pre-defined List" handler could be made to implement a simple selection list, and this configuration would tell the handler the possible choices in the list for this specific attribute type
 
+## Update a concept attribute type
+
 ```console
 POST /conceptattributetype
 {
@@ -68,12 +84,11 @@ POST /conceptattributetype
   "handlerConfig": "dafault"
 }
 ```
-## Update a concept attribute type
-
 *  Update a target concept attribute type with given UUID, this method only modifies properties in the request. Returns a `404 Not Found` 
 status if concept attribute not exists. If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
 
 ### Attributes
+
 
 Parameter | Type | Description
 --- | --- | ---
@@ -86,22 +101,11 @@ Parameter | Type | Description
 *datatypeConfig* | `String` | Provides ability to define custom data types configuration for OpenMRS
 *handlerConfig* | `String` | Allow handler to be used for more than one attribute type. The actual configuration depends on the needs of the specified handler. For example, a "Pre-defined List" handler could be made to implement a simple selection list, and this configuration would tell the handler the possible choices in the list for this specific attribute type
 
-```console
-POST /conceptattributetype
-{
-  "name": "Time Span",
-  "description": "This attribute type will record the time span for the concept",
-  "datatypeClassname": "org.openmrs.customdatatype.datatype.LongFreeTextDatatype",
-  "minOccurs": 0,
-  "maxOccurs": 1,
-  "datatypeConfig": "default",
-  "preferredHandlerClassname": "org.openmrs.web.attribute.handler.LongFreeTextTextareaHandler",
-  "handlerConfig": "dafault"
-}
-```
-
 ## Delete a concept attribute type
 
+```console
+DELETE /conceptattributetype/:target_concept_attribute_type_uuid?purge=true
+```
 * Delete or retire a target concept attribute type by its UUID. Returns
   `404 Not Found` status if concept attribute does not exist. If not 
   authenticated or user does not have sufficient privilege, a 
@@ -113,6 +117,3 @@ POST /conceptattributetype
     --- | --- | ---
     *purge* | `Boolean` | The resource will be retired unless purge = "true"
 
-```console
-DELETE /conceptattributetype/:target_concept_attribute_type_uuid?purge=true
-```

--- a/source/includes/Concepts/concept_data_type.md
+++ b/source/includes/Concepts/concept_data_type.md
@@ -27,25 +27,28 @@
 
 ## List concept data types
 
-* ### List all non-retired concept data types.
-    
-    Get concept data types. Returns a `404 Not Found` status if concept data type not exists. 
-    If the user is not logged in to perform this action, a `401 Unauthorized` status returned. 
+### List all non-retired concept data types.
 
 ```console
 GET /conceptdatatype"
-```
-    
-* ### Get concept data type by UUID.
+```    
+    Get concept data types. Returns a `404 Not Found` status if concept data type not exists. 
+    If the user is not logged in to perform this action, a `401 Unauthorized` status returned. 
 
-    Retrieve a concept data type by its UUID. Returns a `404 Not Found` status if concept data type not exists. If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
     
+### Get concept data type by UUID.
+
 ```console
 GET /conceptdatatype/:target_concept_data_type_uuid
 ```
+    Retrieve a concept data type by its UUID. Returns a `404 Not Found` status if concept data type not exists. If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
+    
     
 ## Delete a concept data type
 
+```console
+DELETE /conceptdatatype/:target_concept_data_type_uuid?purge=true
+```
 * Delete or retire a target concept data type by its UUID. Returns a `404 Not Found` 
   status if concept data not exists. If the user is not logged in to perform this action, 
   a `401 Unauthorized` status returned.
@@ -56,6 +59,3 @@ GET /conceptdatatype/:target_concept_data_type_uuid
     --- | --- | ---
     *purge* | `Boolean` | The resource will be voided/retired unless purge = ‘true’
 
-```console
-DELETE /conceptdatatype/:target_concept_data_type_uuid?purge=true
-```

--- a/source/includes/Concepts/concept_map_type.md
+++ b/source/includes/Concepts/concept_map_type.md
@@ -22,7 +22,11 @@ ANTENATAL VISIT REASON and add them as answers.
 
 ### List concept map types
 
-* #### List all non-retired concept map types.
+### List all non-retired concept map types.
+
+```console
+  GET /conceptmaptype?q="same"
+```
 
     Quickly filter concept map types with a given search query. Returns a `404 Not Found` status if concept map type not exists. 
     If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
@@ -33,32 +37,19 @@ ANTENATAL VISIT REASON and add them as answers.
     --- | --- | ---
     *q* | `String` | Full or partial name search term. Search is case insensitive.
 
-    ```console
-    GET /conceptmaptype?q="same"
-     ```
 
-* #### List concept map type by UUID.
+### List concept map type by UUID.
+
+```console
+  GET /conceptmaptype/:target_concept_map_type_uuid
+```
 
     Retrieve a concept map type by its UUID. Returns a `404 Not Found` status if concept map type not exists. If user not logged 
     in to perform this action, a `401 Unauthorized` status returned.
 
-    ```console
-    GET /conceptmaptype/:target_concept_map_type_uuid
-    ```
 
 ### Create a concept map type
 
-* To Create a concept map type, you need to specify below attributes in the request body. If you are not logged in to perform this action,
- a `401 Unauthorized` status returned.
-
-    #### Attributes
-
-    Parameter | Type | Description
-    --- | --- | ---
-    *name* | `String` | Name of the concept mapping type (Required)
-    *description* | `String` | A brief description of the concept mapping type
-    *isHidden* | `Boolean` | State to record concept map is hidden or not
-    
     ```console
         POST /conceptmaptype
         {
@@ -66,8 +57,27 @@ ANTENATAL VISIT REASON and add them as answers.
           "isHidden": false
         }
     ```
+
+* To Create a concept map type, you need to specify below attributes in the request body. If you are not logged in to perform this action,
+ a `401 Unauthorized` status returned.
+
+### Attributes
+
+    Parameter | Type | Description
+    --- | --- | ---
+    *name* | `String` | Name of the concept mapping type (Required)
+    *description* | `String` | A brief description of the concept mapping type
+    *isHidden* | `Boolean` | State to record concept map is hidden or not
+    
 ### Update a concept map type
 
+```console
+        POST /conceptmaptype
+        {
+          "name": "SAME-AS",
+          "isHidden": true
+        }
+    ```
 *  Update a target concept map type with given UUID, this method only modifies properties in the request. Returns a `404 Not Found` 
 status if concept map not exists. If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
 
@@ -79,15 +89,13 @@ status if concept map not exists. If the user is not logged in to perform this a
     *description* | `String` |  A brief description of the concept mapping type
     *isHidden* | `Boolean` | State to record concept map is hidden or not
     
-    ```console
-        POST /conceptmaptype
-        {
-          "name": "SAME-AS",
-          "isHidden": true
-        }
-    ```
-
+    
 ### Delete a concept map type
+
+
+    ```console
+        DELETE /conceptmaptype/:target_concept_map_type_uuid?purge=true
+    ```
 
 * Delete or Retire a target concept map type by its UUID. Returns a `404 Not Found` status if concept map not exists. If user not logged in to perform this action, a `401 Unauthorized` status returned.
 
@@ -97,6 +105,3 @@ status if concept map not exists. If the user is not logged in to perform this a
     --- | --- | ---
     *purge* | `Boolean` | The resource will be voided/retired unless purge = ‘true’
 
-    ```console
-        DELETE /conceptmaptype/:target_concept_map_type_uuid?purge=true
-     ```

--- a/source/includes/Concepts/concept_reference_term_type.md
+++ b/source/includes/Concepts/concept_reference_term_type.md
@@ -12,36 +12,46 @@
 
 ### List concept reference terms
 
-* #### List all concepts reference terms.
+### List all concepts reference terms.
+
+```console
+    GET /conceptreferenceterm?
+      codeOrName=274663001
+```
 
     Quickly filter concept reference term with given query parameters. Returns a `404 Not Found` status if concept reference term type not exists. If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
 
-    ##### Query Parameters
+### Query Parameters
 
     Parameter | Type | Description
     --- | --- | ---
     *codeOrName* | `String` |  Represents a name from a standard medical code
     *source* | `String` | A concept can have any number of mappings to any number of other vocabularies. Other vocabularies are called "concept sources" in OpenMRS (i.e., LOINC, SNOMED, ICD-9, ICD10, RxNORM, etc.), but the concept source can also be a custom (i.e., org.openmrs.module.mdrtb, PIH, AMPATH, MVP, etc.). Every concept can define a string for its mapping in any "concept source" defined in the database
 
-    ```console
-    GET /conceptreferenceterm?
-      codeOrName=274663001
-     ```
-
-* #### Query concept reference term by UUID.
-
-    Retrieve a concept reference term by its UUID. Returns a `404 Not Found` status if concept reference term not exists. If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
+    
+### Query concept reference term by UUID.
 
     ```console
     GET /conceptreferenceterm/:target_concept_reference_term_type_uuid
     ```
 
+    Retrieve a concept reference term by its UUID. Returns a `404 Not Found` status if concept reference term not exists. If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
+
+
 ### Create a concept reference term
 
+```console
+        POST /conceptreferenceterm
+        {
+          "code": "274663001",
+          "conceptSource": "1ADDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD",
+          "version": "1.0.0"
+        }
+```
 * To Create an concept reference term, you need to specify below attributes in the request body. If you are not logged in to perform this action,
  a `401 Unauthorized` status returned.
 
-    #### Attributes
+### Attributes
 
     Parameter | Type | Description
     --- | --- | ---
@@ -51,20 +61,21 @@
     *conceptSource* | `target_concept_source_UUID` | A concept can have any number of mappings to any number of other vocabularies. Other vocabularies are called "concept sources" in OpenMRS (i.e., LOINC, SNOMED, ICD-9, ICD10, RxNORM, etc.), but the concept source can also be a custom (i.e., org.openmrs.module.mdrtb, PIH, AMPATH, MVP, etc.). Every concept can define a string for its mapping in any "concept source" defined in the database (required)
     *version* | `String` | A method to keep track of the number of updates applied to a specific concept reference term type
 
-    ```console
-        POST /conceptreferenceterm
+    
+### Update a concept reference term
+
+```console
+        POST /conceptreferenceterm/:target_concept_reference_term_type_uuid
         {
           "code": "274663001",
           "conceptSource": "1ADDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD",
-          "version": "1.0.0"
+          "version": "1.0.1"
         }
-    ```
-### Update a concept reference term
-
+```
 *  Update a target concept reference term with given UUID, this method only modifies properties in the request. Returns a `404 Not Found` 
 status if concept reference term not exists. If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
 
-    #### Attributes
+    ### Attributes
 
     Parameter | Type | Description
     --- | --- | ---
@@ -74,16 +85,11 @@ status if concept reference term not exists. If the user is not logged in to per
     *conceptSource* | `target_concept_source_UUID` | A concept can have any number of mappings to any number of other vocabularies. Other vocabularies are called "concept sources" in OpenMRS (i.e., LOINC, SNOMED, ICD-9, ICD10, RxNORM, etc.), but the concept source can also be a custom (i.e., org.openmrs.module.mdrtb, PIH, AMPATH, MVP, etc.). Every concept can define a string for its mapping in any "concept source" defined in the database (required)
     *version* | `String` | A method to keep track of the number of updates applied to a specific concept reference term type
 
-    ```console
-        POST /conceptreferenceterm/:target_concept_reference_term_type_uuid
-        {
-          "code": "274663001",
-          "conceptSource": "1ADDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD",
-          "version": "1.0.1"
-        }
-    ```
-
+    
 ### Delete a concept reference term
+
+```console
+        DELETE /conceptreferenceterm/:target_concept_reference_term_type_uuid?purge=true    ```
 
 * Delete or retire a target concept reference term by its UUID. Returns a `404 Not Found` status if concept reference term not exists. If the user not logged in to perform this action, a `401 Unauthorized` status returned.
 
@@ -93,6 +99,3 @@ status if concept reference term not exists. If the user is not logged in to per
     --- | --- | ---
     *purge* | `Boolean` | The resource will be retired unless purge = ‘true’
 
-    ```console
-        DELETE /conceptreferenceterm/:target_concept_reference_term_type_uuid?purge=true
-     ```

--- a/source/includes/Concepts/concept_source.md
+++ b/source/includes/Concepts/concept_source.md
@@ -16,8 +16,12 @@ The authorities who manage these other concept dictionaries represent "Concept S
 
 ## List concept source
 
-* ### List all non-retired concept source.
-    
+### List all non-retired concept source.
+
+```console
+GET /conceptsource?q="loinc"
+```
+   
     Quickly filter concept source types with a given search query. Returns a `404 Not Found` status if concept source type not exists. 
     If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
     
@@ -27,21 +31,26 @@ The authorities who manage these other concept dictionaries represent "Concept S
     --- | --- | ---
     *q* | `String` | Full or partial match to concept source name. Search is case-insensitive
 
-```console
-GET /conceptsource?q="loinc"
-```
     
-* ### Query concept source by UUID.
+### Query concept source by UUID.
 
-    Retrieve a concept source type by its UUID. Returns a `404 Not Found` status if concept source type not exists. If user not logged 
-    in to perform this action, a `401 Unauthorized` status returned.
-    
 ```console
 GET /conceptsource/:target_concept_source_type_uuid
 ```
+    Retrieve a concept source type by its UUID. Returns a `404 Not Found` status if concept source type not exists. If user not logged 
+    in to perform this action, a `401 Unauthorized` status returned.
+    
    
 ## Create a concept source
 
+```console
+POST /conceptsource
+{
+  "name": "SNOMED CT",
+  "description": "SNOMED Preferred mapping",
+  "hl7Code": "SCT"
+}
+```
 * To Create a concept source type you need to specify below attributes in the request body. If you are not logged in to perform this action,
  a `401 Unauthorized` status returned.
 
@@ -54,16 +63,16 @@ GET /conceptsource/:target_concept_source_type_uuid
     *hl7Code* | `String` | A short code defined by governing bodies like HL7 (as in Vocabulary Table 0396). Alternatively, this could be the "Implementation Id" code used by another OpenMRS installation to define its concepts and forms
     *uniqueId* | `String` | A globally unique id to for the concept source
    
+## Update a concept source
+
 ```console
 POST /conceptsource
 {
-  "name": "SNOMED CT",
-  "description": "SNOMED Preferred mapping",
-  "hl7Code": "SCT"
+ "name": "SNOMED CTS",
+ "description": "SNOMED Preferred mapping",
+ "hl7Code": "SCT"
 }
 ```
-## Update a concept source
-
 *  Update a target concept source type with given UUID, this method only modifies properties in the request. Returns a `404 Not Found` 
 status if concept source not exists. If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
 
@@ -76,17 +85,12 @@ status if concept source not exists. If the user is not logged in to perform thi
     *hl7Code* | `String` | The 5-20 character code defined for this source by governing bodies. Alternatively, this could be the "Implementation Id" code used by another OpenMRS installation to define its concepts and forms
     *uniqueId* | `String` | A globally unique id to for the concept source
     
-```console
-POST /conceptsource
-{
- "name": "SNOMED CTS",
- "description": "SNOMED Preferred mapping",
- "hl7Code": "SCT"
-}
-```
     
 ## Delete a concept source
 
+```console
+DELETE /conceptsource/:target_concept_source_type_uuid?purge=true
+```
 * Delete or Retire a target concept source type by its UUID. Returns a `404 Not Found` status if concept source not exists. If user not logged 
   in to perform this action, a `401 Unauthorized` status returned.
 
@@ -96,6 +100,3 @@ POST /conceptsource
     --- | --- | ---
     *purge* | `Boolean` | The resource will be voided/retired unless purge = ‘true’
 
-```console
-DELETE /conceptsource/:target_concept_source_type_uuid?purge=true
-```

--- a/source/includes/Concepts/concepts_class.md
+++ b/source/includes/Concepts/concepts_class.md
@@ -16,26 +16,34 @@ In this way, the class is helpful for data extraction.  This classification deta
 
 ### List concept classes
 
-* #### List all non-retired concept classes.
-
-    List all concept classes with a given search query. Returns a `404 Not Found` status if concept classes not exist. 
-    If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
+### List all non-retired concept classes.
 
     ```console
     GET /conceptclass"
      ```
 
-* #### List concept class type by UUID.
+    List all concept classes with a given search query. Returns a `404 Not Found` status if concept classes not exist. 
+    If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
 
-    Retrieve a concept class by its UUID. Returns a `404 Not Found` status if concept class type not exists. If user not logged 
-    in to perform this action, a `401 Unauthorized` status returned.
+
+### List concept class type by UUID.
 
     ```console
     GET /conceptclass/:target_concept_class_uuid
     ```
 
+    Retrieve a concept class by its UUID. Returns a `404 Not Found` status if concept class type not exists. If user not logged 
+    in to perform this action, a `401 Unauthorized` status returned.
+
 ### Create a concept class
 
+```console
+        POST /conceptclass
+        {
+          "name": "Procedure",
+          "description": "Describes a clinical procedure"
+        }
+```
 * To Create a concept class, you need to specify below attributes in the request body. If you are not logged in to perform this action,
  a `401 Unauthorized` status returned.
 
@@ -46,15 +54,16 @@ In this way, the class is helpful for data extraction.  This classification deta
     *name* | `String` | Name of the concept class (Required)
     *description* | `String` | Description
 
-    ```console
+    
+### Update a concept class
+
+```console
         POST /conceptclass
         {
           "name": "Procedure",
           "description": "Describes a clinical procedure"
         }
-    ```
-### Update a concept class
-
+```
 *  Update a target concept class with given UUID, this method only modifies properties in the request. Returns a `404 Not Found` 
 status if concept class not exists. If the user not logged in to perform this action, a `401 Unauthorized` status returned.
 
@@ -65,15 +74,13 @@ status if concept class not exists. If the user not logged in to perform this ac
     *name* | `String` | Name of the concept class (Required)
     *description* | `String` | Description
 
-    ```console
-        POST /conceptclass
-        {
-          "name": "Procedure",
-          "description": "Describes a clinical procedure"
-        }
-    ```
+    
 
 ### Delete a concept class
+
+```console
+        DELETE /conceptclass/:target_concept_class_uuid?purge=true
+```
 
 * Delete or Retire a target concept class by its UUID. Returns a `404 Not Found` status if concept class not exists. If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
 
@@ -83,6 +90,4 @@ status if concept class not exists. If the user not logged in to perform this ac
     --- | --- | ---
     *purge* | `Boolean` | The resource will be voided/retired unless purge = ‘true’
 
-    ```console
-        DELETE /conceptclass/:target_concept_class_uuid?purge=true
-     ```
+    

--- a/source/includes/Encounter/encounter.md
+++ b/source/includes/Encounter/encounter.md
@@ -47,11 +47,17 @@ Consultation and Dispensing**.
 
 ## List encounters
 
-* ### List all non-voided encounters.
-    
+### List all non-voided encounters.
+
+```console
+GET /encounter?
+patient=96be32d2-9367-4d1d-a285-79a5e5db12b8
+&fromdate=2016-10-08
+```
+   
     Quickly filter encounters with given query parameters. Returns a `404 Not Found` status if Encounter not exists. If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
     
-    ### Query Parameters
+### Query Parameters
 
     Parameter | Type | Description
     --- | --- | ---
@@ -64,23 +70,33 @@ Consultation and Dispensing**.
     *fromdate* | `Date or Timestamp (ISO 8601)` | Start date of the encounter (must be used with patient)
     *todate* | `Date or Timestamp (ISO 8601)` | End date of the encounter (must be used with patient)
     
-```console
-GET /encounter?
-patient=96be32d2-9367-4d1d-a285-79a5e5db12b8
-&fromdate=2016-10-08
-```
     
-* ### List encounter by UUID.
+### List encounter by UUID.
 
-    Retrieve an encounter by its UUID. Returns a `404 Not Found` status if Encounter not exists. If user not logged 
-    in to perform this action, a `401 Unauthorized` status returned.
-    
 ```console
 GET /encounter/:target_encounter_uuid
 ```
+    Retrieve an encounter by its UUID. Returns a `404 Not Found` status if Encounter not exists. If user not logged 
+    in to perform this action, a `401 Unauthorized` status returned.
+    
    
 ## Create an encounter
 
+```console
+POST /Encounter
+{
+  "encounterDatetime": "2019-10-16 12:08:43",
+  "patient": "070f0120-0283-4858-885d-a20d967729cf",
+  "encounterType": "e22e39fd-7db2-45e7-80f1-60fa0d5a4378",
+  "location": "aff27d58-a15c-49a6-9beb-d30dcfc0c66e",
+  "encounterProviders": [
+    {
+      "provider": "bb1a7781-7896-40be-aaca-7d1b41d843a6",
+      "encounterRole": "240b26f9-dd88-4172-823d-4a8bfeb7841f"
+    }
+  ]
+}
+```
 * To Create an encounter you need to specify below attributes in the request body. If you are not logged in to perform this action,
  a `401 Unauthorized` status returned.
 
@@ -98,8 +114,12 @@ GET /encounter/:target_encounter_uuid
     *form* | `Form UUID` | Target Form UUID to be filled for the encounter
     *visit* | `Visit UUID` | When creating an encounter for an existing visit, this specifies the visit
    
+
+## Update an encounter
+
+
 ```console
-POST /Encounter
+POST /encounter/:target_encounter_uuid
 {
   "encounterDatetime": "2019-10-16 12:08:43",
   "patient": "070f0120-0283-4858-885d-a20d967729cf",
@@ -113,8 +133,6 @@ POST /Encounter
   ]
 }
 ```
-## Update an encounter
-
 *  Update a target encounter with given UUID, this method only modifies properties in the request. Returns a `404 Not Found` 
 status if Encounter not exists. If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
     
@@ -132,24 +150,12 @@ status if Encounter not exists. If the user is not logged in to perform this act
     *form* | `Form UUID` | Target Form UUID to be filled for the encounter
     *visit* | `Visit UUID` | When creating an encounter for an existing visit, this specifies the visit
 
-```console
-POST /encounter/:target_encounter_uuid
-{
-  "encounterDatetime": "2019-10-16 12:08:43",
-  "patient": "070f0120-0283-4858-885d-a20d967729cf",
-  "encounterType": "e22e39fd-7db2-45e7-80f1-60fa0d5a4378",
-  "location": "aff27d58-a15c-49a6-9beb-d30dcfc0c66e",
-  "encounterProviders": [
-    {
-      "provider": "bb1a7781-7896-40be-aaca-7d1b41d843a6",
-      "encounterRole": "240b26f9-dd88-4172-823d-4a8bfeb7841f"
-    }
-  ]
-}
-```
     
 ## Delete an encounter
 
+```console
+  DELETE /encounter/:target_encounter_uuid?purge=true
+```
 * Delete or Void a target encounter by its UUID. Returns a `404 Not Found` status if Encounter not exists. If the user is not logged 
   in to perform this action, a `401 Unauthorized` status returned.
 
@@ -159,32 +165,38 @@ POST /encounter/:target_encounter_uuid
     --- | --- | ---
     *purge* | `Boolean` | The resource will be voided unless purge = ‘true’
 
-```console
-  DELETE /encounter/:target_encounter_uuid?purge=true
-```
 ## List encounter provider subresources
 
-* ### List all encounter provider subresources for a visit.
-
-    Retrieve all <b>encounter provider</b> sub resources of an  <b>encounter</b> resource by target_encounter_uuid. Returns a 
-    `404 Not Found` status if encounter provider not exists. If user not logged in to perform this action, a `401 Unauthorized` status
-    returned.
+### List all encounter provider subresources for a visit.
 
 ```console
 GET /encounter/:target_encounter_uuid/encounterprovider 
 ```
 
-* ### List encounter provider subresources by it's UUID and parent encounter UUID.
+    Retrieve all <b>encounter provider</b> sub resources of an  <b>encounter</b> resource by target_encounter_uuid. Returns a 
+    `404 Not Found` status if encounter provider not exists. If user not logged in to perform this action, a `401 Unauthorized` status
+    returned.
+
+
+### List encounter provider subresources by it's UUID and parent encounter UUID.
+
+```console
+GET /encounter/:target_encounter_uuid/encounterprovider/:target_encounter_provider_uuid
+```
     
      Retrieve an <b>encounter provider</b> sub resources of a <b>encounter</b> resource. Returns a 
      `404 Not Found` status if encounter provider not exists. If you are not logged in to perform this action, a `401 Unauthorized` status
      returned.
      
-```console
-GET /encounter/:target_encounter_uuid/encounterprovider/:target_encounter_provider_uuid
-```
 ## Create an encounter provider sub resource with properties
 
+```console
+POST encounter/:target_encounter_uuid/encounterprovider 
+{
+  "provider": "bb1a7781-7896-40be-aaca-7d1b41d843a6",
+  "encounterRole": "240b26f9-dd88-4172-823d-4a8bfeb7841f"
+}
+```
 * To Create an attribute subresource for a specific visit resource, you need to specify below attributes in the request body.
 If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
 
@@ -195,17 +207,17 @@ If the user is not logged in to perform this action, a `401 Unauthorized` status
     *provider* | `Provider_Type UUID` | UUID of a provider currently registered in OpenMRS (required)
     *encounterRole* | `Encounter_Role UUID` | UUID of encounter role. This is the role provider will participate during this encounter (required)
     
+ 
+ 
+## Update encounter provider subresource
+
 ```console
-POST encounter/:target_encounter_uuid/encounterprovider 
+POST encounter/:target_encounter_uuid/encounterprovider/:target_encounter_provider_uuid
 {
   "provider": "bb1a7781-7896-40be-aaca-7d1b41d843a6",
   "encounterRole": "240b26f9-dd88-4172-823d-4a8bfeb7841f"
 }
 ```
- 
- 
-## Update encounter provider subresource
-
 * Updates an encounter provider subresource value with given UUID, this method will only modify value of the subresource. Returns a `404 Not Found` status if encounter provider not exists. If user not logged in to perform this action, a `401 Unauthorized` status
 returned.
 
@@ -223,15 +235,12 @@ returned.
     *provider* | `Provider UUID` | UUID of a provider currently registered in OpenMRS (required)
     *encounterRole* | `Encounter_Role UUID` | UUID of encounter role. This is the role provider will participate during this encounter (required)
 
-```console
-POST encounter/:target_encounter_uuid/encounterprovider/:target_encounter_provider_uuid
-{
-  "provider": "bb1a7781-7896-40be-aaca-7d1b41d843a6",
-  "encounterRole": "240b26f9-dd88-4172-823d-4a8bfeb7841f"
-}
-```
+
 ## Delete encounter provider subresource
 
+```console
+DELETE /encounter/:target_encounter_uuid/encounterprovider/:target_encounter_provider_uuid
+```
 * Delete or Voided a target encounter provider subresource by its UUID. Returns a `404 Not Found` status if attribute not exists. 
  If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
 
@@ -241,6 +250,3 @@ POST encounter/:target_encounter_uuid/encounterprovider/:target_encounter_provid
     --- | --- | ---
     *purge* | `Boolean` | The resource will be voided unless purge = 'true'. Purging will attempt to remove the encounter provider type from the system irreversibly. Encounter provider types that have been used (i.e., are referenced from existing data) cannot be purged.
 
-```console
-DELETE /encounter/:target_encounter_uuid/encounterprovider/:target_encounter_provider_uuid
-```

--- a/source/includes/Encounter/encounter_role.md
+++ b/source/includes/Encounter/encounter_role.md
@@ -15,33 +15,41 @@ they don't have to (e.g., "Lead Surgeon").
 
 ## List encounter roles
 
-* ### List all non-voided encounter roles.
-    
-    Quickly filter encounter roles with given query parameters. Returns a `404 Not Found` status if encounter roles not exist. 
-     If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
-    
-    ##### Query Parameters
-
-    Parameter | Type | Description
-    --- | --- | ---
-    *q* | `Search Query` | Query to filter encounter role by its name
+### List all non-voided encounter roles.
 
 ```console
 GET /encounterrole?
     q=Clinician
 ```
     
-* ### Get encounter role by UUID.
-
-    Retrieve an encounter role by its UUID. Returns a `404 Not Found` status if encounter role not exists. If user not logged 
-    in to perform this action, a `401 Unauthorized` status returned.
+    Quickly filter encounter roles with given query parameters. Returns a `404 Not Found` status if encounter roles not exist. 
+     If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
     
+### Query Parameters
+
+    Parameter | Type | Description
+    --- | --- | ---
+    *q* | `Search Query` | Query to filter encounter role by its name
+
+    
+### Get encounter role by UUID.
+
 ```console
 GET /encounter/:target_encounter_role_uuid
 ```
+    Retrieve an encounter role by its UUID. Returns a `404 Not Found` status if encounter role not exists. If user not logged 
+    in to perform this action, a `401 Unauthorized` status returned.
+    
    
 ## Create an encounter role
 
+```console
+POST /encounterrole
+{
+    "name": "Clinician",
+    "description": "A provider assisting the Lead Surgeon."
+}
+```
 * To Create an encounter role, you need to specify below attributes in the request body. If you are not logged in to perform 
 this action, a `401 Unauthorized` status returned.
 
@@ -52,15 +60,16 @@ this action, a `401 Unauthorized` status returned.
     *name* | `String` | Name for the encounter role (required)
     *description* | `String | Description for the encounter role (required)
    
-```console
-POST /encounterrole
-{
-    "name": "Clinician",
-    "description": "A provider assisting the Lead Surgeon."
-}
-```
+
 ## Update an encounter role
 
+```console
+POST /encounterrole/:target_encounter_role_uuid
+{
+    "name": "Assisting Surgeon"",
+    "description": "A surgeon who assisted the Lead Surgeon"
+}
+```
 *  Update a target encounter role with given UUID, this method only modifies properties in the request. Returns a `404 Not Found` 
 status if encounter role not exists. If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
     
@@ -71,16 +80,13 @@ status if encounter role not exists. If the user is not logged in to perform thi
     *name* | `String` | Name for the encounter role
     *description* | `String | Description for the encounter role
     
-```console
-POST /encounterrole/:target_encounter_role_uuid
-{
-    "name": "Assisting Surgeon"",
-    "description": "A surgeon who assisted the Lead Surgeon"
-}
-```
+
     
 ## Delete an encounter role
 
+```console
+DELETE /encounterrole/:target_encounter_role_uuid?purge=true
+```
 * Delete or Void a target encounter role by its UUID. Returns a `404 Not Found` status if encounter role not exists. If the user is
  not logged in to perform this action, a `401 Unauthorized` status returned.
 
@@ -90,6 +96,3 @@ POST /encounterrole/:target_encounter_role_uuid
     --- | --- | ---
     *purge* | `Boolean` | The resource will be voided unless purge = ‘true’
 
-```console
-DELETE /encounterrole/:target_encounter_role_uuid?purge=true
-```

--- a/source/includes/Encounter/encounter_type.md
+++ b/source/includes/Encounter/encounter_type.md
@@ -17,33 +17,42 @@
 
 ## List encounter types
 
-* ### List all  not-retired encounter types.
-    
-    Quickly filter encounter types with given query parameters. Returns a `404 Not Found` status if encounter types not exist. 
-    If the user not logged in to perform this action, a `401 Unauthorized` status returned.
-    
-    ##### Query Parameters
-
-    Parameter | Type | Description
-    --- | --- | ---
-    *q* | `Search Query` | Query to filter encounter type by its name
+### List all  not-retired encounter types.
 
 ```console
 GET /encountertype?
     q=Admission
 ```
+
+    Quickly filter encounter types with given query parameters. Returns a `404 Not Found` status if encounter types not exist. 
+    If the user not logged in to perform this action, a `401 Unauthorized` status returned.
     
-* ### Get encounter type by UUID.
+### Query Parameters
+
+    Parameter | Type | Description
+    --- | --- | ---
+    *q* | `Search Query` | Query to filter encounter type by its name
+
+    
+### Get encounter type by UUID.
+
+```console
+GET /encountertype/:target_encounter_type_uuid
+```
 
     Retrieve an encounter type by its UUID. Returns a `404 Not Found` status if encounter type not exists. If the user is not logged 
     in to perform this action, a `401 Unauthorized` status returned.
     
-```console
-GET /encountertype/:target_encounter_type_uuid
-```
    
 ## Create an encounter type
 
+```console
+POST /encountertype
+{
+    "name": "Discharge",
+    "description": "Attach encounters related to hospital dischargers"
+}
+```
 * To create an encounter type, you need to specify below attributes in the request body. If you are not logged in to perform 
 this action, a `401 Unauthorized` status returned.
 
@@ -54,15 +63,16 @@ this action, a `401 Unauthorized` status returned.
     *name* | `String` | Name for the encounter type (required)
     *description* | `String` | Description for the encounter type (required)
    
-```console
-POST /encountertype
-{
-    "name": "Discharge",
-    "description": "Attach encounters related to hospital dischargers"
-}
-```
+
 ## Update an encounter type
 
+```console
+POST /encountertype/:target_encounter_type_uuid
+{
+    "name": "Discharge",
+    "description": "Encounters related to hospital dischargers"
+}
+```
 *  Update a target encounter type with given UUID, this method only modifies properties in the request. Returns a `404 Not Found` 
 status if encounter type not exists. If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
     
@@ -73,16 +83,13 @@ status if encounter type not exists. If the user is not logged in to perform thi
     *name* | `String` | Name for the encounter type
     *description* | `String` | Description for the encounter type
     
-```console
-POST /encountertype/:target_encounter_type_uuid
-{
-    "name": "Discharge",
-    "description": "Encounters related to hospital dischargers"
-}
-```
+
     
 ## Delete an encounter type
 
+```console
+DELETE /encountertype/:target_encounter_type_uuid?purge=true
+```
 * Delete or retire a target encounter type by its UUID. Returns a `404 Not Found` status if encounter type not exists. If the user is 
  not logged in to perform this action, a `401 Unauthorized` status returned.
 
@@ -92,6 +99,3 @@ POST /encountertype/:target_encounter_type_uuid
     --- | --- | ---
     *purge* | `Boolean` | The resource will be retired unless purge = ‘true’
 
-```console
-DELETE /encountertype/:target_encounter_type_uuid?purge=true
-```

--- a/source/includes/Location/location.md
+++ b/source/includes/Location/location.md
@@ -37,54 +37,32 @@ Amani Clinic.
 
 ## List location
 
-* ### List all non-retired locations`.
+```console
+GET /location?
+q="amani"
+```
+### List all non-retired locations`.
     
     Quickly filter location with given query parameters. Returns a `404 Not Found` status if the location not exists. If the 
     user not logged in to perform this action, a `401 Unauthorized` status returned.
     
-    ### Query Parameters
+### Query Parameters
 
     Parameter | Type | Description
     --- | --- | ---
     *q* | `Search Query` | Display Name of Location object.
      
-```console
-GET /location?
-q="amani"
-```
     
-* ### List location by UUID.
+### List location by UUID.
 
-    Retrieve a location by its UUID. Returns a `404 Not Found` status if the location not exists. If the user not logged 
-    in to perform this action, a `401 Unauthorized` status returned.
-    
 ```console
 GET /location/:target_location_uuid
 ```
+    Retrieve a location by its UUID. Returns a `404 Not Found` status if the location not exists. If the user not logged 
+    in to perform this action, a `401 Unauthorized` status returned.
+    
    
 ## Create a location
-
-* To Create a location you need to specify below attributes in the request body. If the user not logged in to perform this action,
- a `401 Unauthorized` status returned.
-
-    ### Attributes
-
-    Parameter | Type | Description
-    --- | --- | ---
-    *name* | `String` | Name of the location (Required)
-    *address1* | `String` | Address of the location (Required)
-    *description* | `String` | Description
-    *cityVillage* | `String` | City/village
-    *stateProvince* | `String` | State and province
-    *country* | `String` | Country    
-    *postalCode* | `String` | Postal code of the location 
-    *latitude* | `String` | Latitude    
-    *longitude* | `String` | Longitude
-    *countyDistrict* | `String` | District or Country
-    *tags* | `Array[]: LocationTag UUID` | UUID's of the location tags
-    *parentLocation* | `Parent Location UUID` | UUID of the target parent location
-    *childLocations* | `Array[]: Child Location UUID` | UUID's of the target child locations
-    *attributes* | `Array[]: Attribute UUID` | UUID's of location attributes  
 
 ```console
 POST /location
@@ -115,18 +93,9 @@ POST /location
     ]
 }
 ```
+* To Create a location you need to specify below attributes in the request body. If the user not logged in to perform this action,
+ a `401 Unauthorized` status returned.
 
-## Update a location
-
-*  Update a target location with given UUID, this method only modifies properties in the request. Returns a `404 Not Found` 
-status if the location not exists. If the user not logged in to perform this action, a `401 Unauthorized` status returned.
-
-    ### Query Parameters
-
-    Parameter | Type | Description
-    --- | --- | ---
-    *uuid* | `target_location_uuid` | Target location resource UUID
-    
     ### Attributes
 
     Parameter | Type | Description
@@ -145,6 +114,10 @@ status if the location not exists. If the user not logged in to perform this act
     *parentLocation* | `Parent Location UUID` | UUID of the target parent location
     *childLocations* | `Array[]: Child Location UUID` | UUID's of the target child locations
     *attributes* | `Array[]: Attribute UUID` | UUID's of location attributes  
+
+
+## Update a location
+
 
 ```console
 POST /location/:target_location_uuid
@@ -175,9 +148,40 @@ POST /location/:target_location_uuid
     ]
 }       
 ```
+*  Update a target location with given UUID, this method only modifies properties in the request. Returns a `404 Not Found` 
+status if the location not exists. If the user not logged in to perform this action, a `401 Unauthorized` status returned.
+
+    ### Query Parameters
+
+    Parameter | Type | Description
+    --- | --- | ---
+    *uuid* | `target_location_uuid` | Target location resource UUID
+    
+    ### Attributes
+
+    Parameter | Type | Description
+    --- | --- | ---
+    *name* | `String` | Name of the location (Required)
+    *address1* | `String` | Address of the location (Required)
+    *description* | `String` | Description
+    *cityVillage* | `String` | City/village
+    *stateProvince* | `String` | State and province
+    *country* | `String` | Country    
+    *postalCode* | `String` | Postal code of the location 
+    *latitude* | `String` | Latitude    
+    *longitude* | `String` | Longitude
+    *countyDistrict* | `String` | District or Country
+    *tags* | `Array[]: LocationTag UUID` | UUID's of the location tags
+    *parentLocation* | `Parent Location UUID` | UUID of the target parent location
+    *childLocations* | `Array[]: Child Location UUID` | UUID's of the target child locations
+    *attributes* | `Array[]: Attribute UUID` | UUID's of location attributes  
+
     
 ## Delete a location
 
+```console
+DELETE /location/:target_location_uuid?purge=true
+```
 * Delete or Retire a target location by its UUID. Returns a `404 Not Found` status if the location not exists. If the user not logged 
   in to perform this action, a `401 Unauthorized` status returned.
 
@@ -187,32 +191,36 @@ POST /location/:target_location_uuid
     --- | --- | ---
     *purge* | `Boolean` | The resource will be voided/retired unless purge = ‘true’
 
-```console
-DELETE /location/:target_location_uuid?purge=true
-```
 ## List location attribute subresources
 
-* ### List all location attribute subresources for a location.
-
-    Retrieve all <b>attribute</b> sub resources of a  <b>location</b> resource by target_location_uuid.Returns a 
-    `404 Not Found` status if the attribute not exists. If the user not logged in to perform this action, a `401 Unauthorized` status
-    returned.
+### List all location attribute subresources for a location.
 
 ```console
 GET /location/:target_location_uuid/attribute 
 ```
+    Retrieve all <b>attribute</b> sub resources of a  <b>location</b> resource by target_location_uuid.Returns a 
+    `404 Not Found` status if the attribute not exists. If the user not logged in to perform this action, a `401 Unauthorized` status
+    returned.
 
-* ### List location attribute subresources by own UUID and parent location UUID.
-    
+
+### List location attribute subresources by own UUID and parent location UUID.
+
+```console
+GET /location/:target_location_uuid/attribute/:target_attribute_uuid
+```    
      Retrieve an <b>attribute</b> sub resources of a <b>location</b> resource.Returns a 
      `404 Not Found` status if the attribute not exists. If the user are not logged in to perform this action, a `401 Unauthorized` status
      returned.
      
-```console
-GET /location/:target_location_uuid/attribute/:target_attribute_uuid
-```
 ## Create a location attribute subresource with properties
 
+```console
+POST location/:target_location_uuid/attribute 
+{
+    "attributeType": "target_location_attribute_type_uuid",
+    "value": "value_for_the_attriute"
+}
+```
 * To Create an attribute subresource for a specific location resource, you need to specify below attributes in the request body.
 If the user not logged in to perform this action, a `401 Unauthorized` status returned.
 
@@ -223,17 +231,18 @@ If the user not logged in to perform this action, a `401 Unauthorized` status re
     *attributeType* | `Attribute_Type UUID` | Create Attribute from this Location Attribute_Type
     *value* | `Depends on Attribute_Type Selected` | Value for the attribute
 
-```console
-POST location/:target_location_uuid/attribute 
-{
-    "attributeType": "target_location_attribute_type_uuid",
-    "value": "value_for_the_attriute"
-}
-```
  
  
 ## Update a location attribute subresource
 
+
+```console
+POST location/:target_location_uuid/attribute/:target_location_attribute_uuid
+{
+    "attributeType": "target_attribute_type_uuid",
+    "value": "modified_attriute_value"
+} 
+```
 * Updates a location attribute sub resource value with given UUID, this method will only modify the value of the subresource. Returns a `404 Not Found` status if the attribute not exists. If the user not logged in to perform this action, a `401 Unauthorized` status
 returned.
 
@@ -244,16 +253,12 @@ returned.
     *attributeType* | `Attribute_Type UUID` | Location Attribute_Type resource UUID
     *updated value* | `Depends on Attribute_Type Selected` | Updated value for the attribute
 
-```console
-POST location/:target_location_uuid/attribute/:target_location_attribute_uuid
-{
-    "attributeType": "target_attribute_type_uuid",
-    "value": "modified_attriute_value"
-} 
-```
 
 ## Delete a location attribute subresource
 
+```console
+DELETE /location/:target_location_uuid/attribute/:target_location_attribute_uuid
+```
 * Delete or Retire a target location attribute subresource by its UUID. Returns a `404 Not Found` status if the attribute not exists. 
 If the user not logged in to perform this action, a `401 Unauthorized` status returned.
 
@@ -263,6 +268,3 @@ If the user not logged in to perform this action, a `401 Unauthorized` status re
     --- | --- | ---
     *purge* | `Boolean` | The resource will be voided/retired unless purge = ‘true’
     
-```console
-DELETE /location/:target_location_uuid/attribute/:target_location_attribute_uuid
-```

--- a/source/includes/Location/location_attribute_type.md
+++ b/source/includes/Location/location_attribute_type.md
@@ -14,8 +14,11 @@
 
 ### List location attribute types
 
-* ### List all non-retired location attribute types.
+### List all non-retired location attribute types.
 
+```console
+GET /locationattributetype?q="humidity"
+```
     Quickly filter location attribute types with a given search query. Returns a `404 Not Found` status if the location attribute type not exists.
      If the user not logged in to perform this action, a `401 Unauthorized` status returned.
 
@@ -25,21 +28,31 @@
     --- | --- | ---
     *q* | `Search Query` | Display Name of Location attribute type.
 
-```console
-GET /locationattributetype?q="humidity"
-```
 
-* ### List location attribute type by UUID.
-
-    Retrieve a location attribute type by its UUID. Returns a `404 Not Found` status if the location attribute type not exists. If the 
-    user not logged in to perform this action, a `401 Unauthorized` status returned.
+### List location attribute type by UUID.
 
 ```console
 GET /locationattributetype/:target_location_attribute_type_uuid
 ```
+    Retrieve a location attribute type by its UUID. Returns a `404 Not Found` status if the location attribute type not exists. If the 
+    user not logged in to perform this action, a `401 Unauthorized` status returned.
+
 
 ## Create a location attribute type
 
+```console
+POST /locationattributetype
+{
+  "name": "humidity",
+  "description": "This attribute type will record the humidity of the location",
+  "datatypeClassname": "org.openmrs.customdatatype.datatype.LongFreeTextDatatype",
+  "minOccurs": 0,
+  "maxOccurs": 1,
+  "datatypeConfig": "default",
+  "preferredHandlerClassname": "org.openmrs.web.attribute.handler.LongFreeTextTextareaHandler",
+  "handlerConfig": "dafault"
+}
+```
 * To Create a location attribute type, you need to specify below attributes in the request body. If the user not logged in to perform this action,
  a `401 Unauthorized` status returned.
 
@@ -56,21 +69,21 @@ GET /locationattributetype/:target_location_attribute_type_uuid
     *datatypeConfig* | `String` | Allow the data type have any name and config it wants/needs.
     *handlerConfig* | `String` | Allow the handler have any name and config it wants/needs. This will help to identify the data type unambiguously which has been contained and will allow introspecting
 
+## Update a location attribute type
+
 ```console
-POST /locationattributetype
+POST /locationattributetype/:target_location_attribute_type_uuid
 {
   "name": "humidity",
-  "description": "This attribute type will record the humidity of the location",
+  "description": "This attribute type will record the humidity of the location"",
   "datatypeClassname": "org.openmrs.customdatatype.datatype.LongFreeTextDatatype",
   "minOccurs": 0,
-  "maxOccurs": 1,
+  "maxOccurs": 2,
   "datatypeConfig": "default",
   "preferredHandlerClassname": "org.openmrs.web.attribute.handler.LongFreeTextTextareaHandler",
   "handlerConfig": "dafault"
 }
 ```
-## Update a location attribute type
-
 *  Update a target location attribute type with given UUID, this method only modifies properties in the request. Returns a `404 Not Found` 
 status if the location attribute not exists. If the user not logged in to perform this action, a `401 Unauthorized` status returned.
 
@@ -93,22 +106,13 @@ status if the location attribute not exists. If the user not logged in to perfor
       *datatypeConfig* | `String` | Allow the data type have any name and config it wants/needs.
       *handlerConfig* | `String` | Allow the handler have any name and config it wants/needs. This will help to identify the data type unambiguously which has been contained and will allow introspecting
 
-```console
-POST /locationattributetype/:target_location_attribute_type_uuid
-{
-  "name": "humidity",
-  "description": "This attribute type will record the humidity of the location"",
-  "datatypeClassname": "org.openmrs.customdatatype.datatype.LongFreeTextDatatype",
-  "minOccurs": 0,
-  "maxOccurs": 2,
-  "datatypeConfig": "default",
-  "preferredHandlerClassname": "org.openmrs.web.attribute.handler.LongFreeTextTextareaHandler",
-  "handlerConfig": "dafault"
-}
-```
+
 
 ## Delete a location attribute type
 
+```console
+DELETE /locationattributetype/:target_location_attribute_type_uuid?purge=true
+```
 * Delete or Retire a target location attribute type by its UUID. Returns a `404 Not Found` status if the location attribute type not exists. If the user not logged in to perform this action, a `401 Unauthorized` status returned.
 
     ### Query Parameters
@@ -117,6 +121,3 @@ POST /locationattributetype/:target_location_attribute_type_uuid
     --- | --- | ---
     *purge* | `Boolean` | The resource will be voided/retired unless purge = ‘true’. Purging will attempt to irreversibly remove the attribute type from the system. Attribute types that have been used (i.e., are referenced from existing data) cannot be purged.
 
-```console
-DELETE /locationattributetype/:target_location_attribute_type_uuid?purge=true
-```

--- a/source/includes/Location/location_tag.md
+++ b/source/includes/Location/location_tag.md
@@ -20,7 +20,11 @@
 
 ## List location tags
 
-* ### List all non-retired location tags.
+### List all non-retired location tags.
+
+```console
+GET /locationtag?q="visit"
+```
 
     Quickly filter location tags with a given search query. Returns a `404 Not Found` status if the location tag not exists.
     If the user not logged in to perform this action, a `401 Unauthorized` status returned.
@@ -31,21 +35,26 @@
     --- | --- | ---
     *q* | `Search Query` | Display Name of Location location tag type.
 
-```console
-GET /locationtag?q="visit"
-```
 
-* ### List location tag by UUID.
-
-    Retrieve a location tag by its UUID. Returns a `404 Not Found` status if the location tag type not exists. If the 
-    user not logged in to perform this action, a `401 Unauthorized` status returned.
+### List location tag by UUID.
 
 ```console
 GET /locationtag/:target_location_tag_uuid
 ```
+    Retrieve a location tag by its UUID. Returns a `404 Not Found` status if the location tag type not exists. If the 
+    user not logged in to perform this action, a `401 Unauthorized` status returned.
+
 
 ## Create a location tag
 
+```console
+POST /locationtag
+{
+  "name": "Visit Location",
+  "description": "Visits are only allowed to happen at locations tagged with this location tag.",
+  "retired": false
+}
+```
 * To Create a location tag, you need to specify below attributes in the request body. If the user not logged in to perform this action,
  a `401 Unauthorized` status returned.
 
@@ -58,17 +67,18 @@ GET /locationtag/:target_location_tag_uuid
     *retired* | `Boolean` | Retired status of the location tag
     *retiredReason* | `String` | For location tags that are retired, this may contain an explanation of why the location tag was retired.
 
-```console
-POST /locationtag
-{
-  "name": "Visit Location",
-  "description": "Visits are only allowed to happen at locations tagged with this location tag.",
-  "retired": false
-}
-```
 
 ## Update a location tag
 
+```console
+POST /locationtag/:target_location_tag_uuid
+{
+  "name": "Visit Location",
+  "description": "Visits are only allowed to happen at locations tagged with this location tag.",
+  "retired": true,
+  "retiredReason": "Not valid anymore"
+}
+```
 *  Update a target location tag with given UUID, this method only modifies properties in the request. Returns a `404 Not Found` 
 status if the location tag not exists. If the user not logged in to perform this action, a `401 Unauthorized` status returned.
 
@@ -87,18 +97,12 @@ status if the location tag not exists. If the user not logged in to perform this
       *retired* | `Boolean` | Retired status of the location tag
       *retiredReason* | `String` | For location tags that are retired, this may contain an explanation of why the location tag was retired.
 
-```console
-POST /locationtag/:target_location_tag_uuid
-{
-  "name": "Visit Location",
-  "description": "Visits are only allowed to happen at locations tagged with this location tag.",
-  "retired": true,
-  "retiredReason": "Not valid anymore"
-}
-```
 
 ## Delete a location tag
 
+```console
+DELETE /locationtag/:target_location_tag_uuid?purge=true
+```
 * Delete or Retire a target location tag type by its UUID. Returns a `404 Not Found` status if the location tag not exists. If the user not logged in to perform this action, a `401 Unauthorized` status returned.
 
     ### Query Parameters
@@ -107,6 +111,3 @@ POST /locationtag/:target_location_tag_uuid
     --- | --- | ---
     *purge* | `Boolean` | The resource will be voided/retired unless purge = ‘true’. Purging will attempt to remove the tag from the system irreversibly. Location tags types that have been used (i.e., are referenced from existing data) cannot be purged.
 
-```console
-DELETE /locationtag/:target_location_tag_uuid?purge=true
-```

--- a/source/includes/Observations/obs.md
+++ b/source/includes/Observations/obs.md
@@ -21,35 +21,44 @@ Examples of observations include Serum Creatinine of 0.9mg/dL or Review of cardi
 
 ## List observations
 
-* ### List all observations.
-    
+### List all observations.
+
+```console
+GET /obs?patient=070f0120-0283-4858-885d-a20d967729cf"
+```    
     Quickly filter observations with given query parameters. 
 If not authenticated or authenticated user does not have sufficient privileges, a `401 Unauthorized` 
 status is returned.
 
-    ### Query Parameters
+### Query Parameters
 
     Parameter | Type | Description
     --- | --- | ---
     *patient* | `target_patient_uuid` | patient resource UUID
     *concept* | `target_concept_uuid`| concept resource UUID (this parameter to be used with patient)
 
-```console
-GET /obs?patient=070f0120-0283-4858-885d-a20d967729cf"
- ```
     
-* ### Query observations by UUID.
+### Query observations by UUID.
 
+```console
+GET /obs/:target_observation_uuid
+```
     Retrieve an observation by its UUID.
 If not authenticated or authenticated user does not have sufficient privileges, a `401 Unauthorized` 
 status is returned.
     
-```console
-GET /obs/:target_observation_uuid
-```
    
 ## Create an observation
 
+```console
+POST /obs 
+{
+  "person": "070f0120-0283-4858-885d-a20d967729cf",
+  "concept": "5089AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+  "obsDatetime": "2019-11-14T07:37:31.000+0000",
+  "value": 70
+}
+```
 * To Create an observation you need to specify below attributes in the request body. If not authenticated or authenticated user does not have sufficient privileges, a `401 Unauthorized` 
 status is returned.
 
@@ -71,17 +80,14 @@ status is returned.
     *interpretation* | `String` | `NORMAL`, `ABNORMAL`, `CRITICALLY_ABNORMAL`, `NEGATIVE`, `POSITIVE`,`CRITICALLY_LOW`,  `LOW`, `HIGH`, `CRITICALLY_HIGH`, `VERY_SUSCEPTIBLE`, `SUSCEPTIBLE`, `INTERMEDIATE`, `RESISTANT`, `SIGNIFICANT_CHANGE_DOWN`, `SIGNIFICANT_CHANGE_UP`, `OFF_SCALE_LOW`, `OFF_SCALE_HIGH`
     *voided* | `Boolean` | true if the observation is voided
     
-```console
-POST /obs 
-{
-  "person": "070f0120-0283-4858-885d-a20d967729cf",
-  "concept": "5089AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-  "obsDatetime": "2019-11-14T07:37:31.000+0000",
-  "value": 70
-}
-```
 ## Update an observation
 
+```console
+POST /obs/:uuid_of_obs_to_be_updated
+{
+  "value": 71
+}
+```
 *  Update a target obs, this method only modifies properties in the request. Returns `404 Not Found` status if the observation does not exist. 
 If not authenticated or authenticated user does not have sufficient privileges, a `401 Unauthorized` 
 status is returned.
@@ -104,14 +110,12 @@ status is returned.
     *interpretation* | `String` | `NORMAL`, `ABNORMAL`, `CRITICALLY_ABNORMAL`, `NEGATIVE`, `POSITIVE`,`CRITICALLY_LOW`,  `LOW`, `HIGH`, `CRITICALLY_HIGH`, `VERY_SUSCEPTIBLE`, `SUSCEPTIBLE`, `INTERMEDIATE`, `RESISTANT`, `SIGNIFICANT_CHANGE_DOWN`, `SIGNIFICANT_CHANGE_UP`, `OFF_SCALE_LOW`, `OFF_SCALE_HIGH`
     *voided* | `Boolean` | true if the observation is voided
    
-```console
-POST /obs/:uuid_of_obs_to_be_updated
-{
-  "value": 71
-}
-```
     
 ## Delete an observation
+
+```console
+DELETE /obs/:target_obs_uuid?purge=true
+```
 
 * Delete or void a target observation. Returns `404 Not Found` status if the observation does not exist. 
 If not authenticated or authenticated user does not have sufficient privileges, a `401 Unauthorized` 
@@ -123,6 +127,3 @@ status is returned.
     --- | --- | ---
     *purge* | `Boolean` | The resource will be voided unless purge = ‘true’
 
-```console
-DELETE /obs/:target_obs_uuid?purge=true
-```

--- a/source/includes/Orders/order.md
+++ b/source/includes/Orders/order.md
@@ -17,29 +17,40 @@ An Order only records an intention, not whether or not the action is carried out
 
 ## List orders
 
+```console
+GET /order?q=penicillin
+```
 * Fetch all non-retired orders that match any specified parameters otherwise fetch all non-retired orders. 
 If not authenticated or authenticated user does not have sufficient privileges, a `401 Unauthorized` status is returned.
 
-    #### Query Parameters
+### Query Parameters
 
     Parameter | Type | Description
     --- | --- | ---
     *q* | `String` | Full or partial display name of order
 
-```console
-GET /order?q=penicillin
- ```
 
-* ### Get a particular order
-
-    Retrieve a particular order. If not authenticated or authenticated user does not have sufficient privileges, a `401 Unauthorized` status is returned.
+### Get a particular order
 
 ```console
 GET /order/:target_order_uuid
 ```
+    Retrieve a particular order. If not authenticated or authenticated user does not have sufficient privileges, a `401 Unauthorized` status is returned.
+
 
 ## Create an order
 
+
+```console
+POST /order
+{
+  "encounter": "69f83020-caf2-4c9e-bca7-89b8e62b52e1",
+  "action": "new",
+  "urgency": "ROUTINE",
+  "patient": "070f0120-0283-4858-885d-a20d967729cf",
+  "dateActivated": "2018-10-16 12:08:43"
+}
+```
 * To create a role you need to specify below attributes in the request body. If not authenticated or authenticated user does not have sufficient privileges, a `401 Unauthorized` status is returned.
 
     ### Attributes
@@ -60,19 +71,20 @@ GET /order/:target_order_uuid
     *dateActivated* | `Date` | the start date of the order
     *dateStopped* | `Date` | the date of discontinuation
 
+    
+## Update an order
+
+
 ```console
-POST /order
+POST /order/:target_order_uuid
 {
   "encounter": "69f83020-caf2-4c9e-bca7-89b8e62b52e1",
   "action": "new",
   "urgency": "ROUTINE",
   "patient": "070f0120-0283-4858-885d-a20d967729cf",
-  "dateActivated": "2018-10-16 12:08:43"
+  "dateStopped": "2019-03-12 11:48:23"
 }
 ```
-    
-## Update an order
-
 * Update an order with given UUID, this method only modifies properties in the request. If the user not logged in to perform this action, a `401 Unauthorized` status returned.
 
     ### Attributes
@@ -93,18 +105,11 @@ POST /order
     *dateActivated* | `Date` | the start date of the order
     *dateStopped* | `Date` | the date of discontinuation
 
-```console
-POST /order/:target_order_uuid
-{
-  "encounter": "69f83020-caf2-4c9e-bca7-89b8e62b52e1",
-  "action": "new",
-  "urgency": "ROUTINE",
-  "patient": "070f0120-0283-4858-885d-a20d967729cf",
-  "dateStopped": "2019-03-12 11:48:23"
-}
-```
-
 ## Delete an order
+
+```console
+DELETE /order/:target_order_uuid?purge=true
+```
 
 * Delete or void an order by its UUID. If not authenticated or authenticated user does not have sufficient privileges, a `401 Unauthorized` status is returned.
 
@@ -114,6 +119,3 @@ POST /order/:target_order_uuid
     --- | --- | ---
     *purge* | `Boolean` | The resource will be voided unless purge = ‘true’.Purging will attempt to irreversibly remove the attribute type from the system. Attribute types that have been used (i.e., are referenced from existing data) cannot be purged.
 
-```console
-DELETE /order/:target_order_uuid?purge=true
- ```

--- a/source/includes/Orders/order_type.md
+++ b/source/includes/Orders/order_type.md
@@ -20,23 +20,31 @@ new order type are also being added to the system (using a module or app).
 
 ## List orders
 
-* Fetch all non-retired order types that match any specified parameters otherwise fetch all non-retired order types. If not authenticated or authenticated user does not have sufficient privileges, a `401 Unauthorized` status is returned.
-
 ```console
 GET /ordertype
- ```
+```
+* Fetch all non-retired order types that match any specified parameters otherwise fetch all non-retired order types. If not authenticated or authenticated user does not have sufficient privileges, a `401 Unauthorized` status is returned.
 
-* ### Get a particular order type
 
-    Retrieve a particular order.
-If not authenticated or authenticated user does not have sufficient privileges, a `401 Unauthorized` status is returned.
+### Get a particular order type
 
 ```console
 GET /ordertype/:target_ordertype_uuid
 ```
+    Retrieve a particular order.
+If not authenticated or authenticated user does not have sufficient privileges, a `401 Unauthorized` status is returned.
+
 
 ## Create an order type
 
+```console
+POST /ordertype
+{
+  "name": "drug order",
+  "description": "One 500mg tablet of Ciprofloxacin, twice a day",
+  "parent": "070f0120-0283-4858-885d-a20d967729cf",
+}
+```
 * Order types depend on code within the application to properly handle them, so it would be unusual to create a new order type unless some new code (e.g., a module) has been added to the system to handle the new order type.
 
     #### Attributes
@@ -49,17 +57,16 @@ GET /ordertype/:target_ordertype_uuid
     *parent* | `Order UUID` | the order uuid
     *conceptClasses* | `Array[] : Concept UUID` | classes of concepts that can be used to generate an order of this type
 
-```console
-POST /ordertype
-{
-  "name": "drug order",
-  "description": "One 500mg tablet of Ciprofloxacin, twice a day",
-  "parent": "070f0120-0283-4858-885d-a20d967729cf",
-}
-```
     
 ## Update an order type
 
+```console
+POST /ordertype/:target_ordertype_uuid
+{
+  "name": "drug order",
+  "description": "One 400mg tablet of Ciprofloxacin, twice a day"
+}
+```
 * Update an order type with given UUID, this method only modifies properties in the request. If the user not logged in to perform this action, a `401 Unauthorized` status returned.
 
     ### Attributes
@@ -72,18 +79,11 @@ POST /ordertype
     *parent* | `Order UUID` | the order uuid
     *conceptClasses* | `Array[] : Concept UUID` | classes of concepts that can be used to generate an order of this type
 
-```console
-POST /ordertype/:target_ordertype_uuid
-{
-  "name": "drug order",
-  "description": "One 400mg tablet of Ciprofloxacin, twice a day"
-}
-```
 
 ## Delete an order type
 
-* Delete or retire an order type by its UUID. If not authenticated or authenticated user does not have sufficient privileges, a `401 Unauthorized` status is returned.
-
 ```console
 DELETE /ordertype/:target_ordertype_uuid
- ```
+```
+* Delete or retire an order type by its UUID. If not authenticated or authenticated user does not have sufficient privileges, a `401 Unauthorized` status is returned.
+

--- a/source/includes/Patient/patient_identifier_type.md
+++ b/source/includes/Patient/patient_identifier_type.md
@@ -26,23 +26,38 @@ Administrators define what types of identifiers they will collect. These range f
 
 ## List PatientIdentifierType resource
 
-* ### List patientIdentifierType
-
-    Fetch all non-retired patientIdentifierTypes resources that match any specified parameters otherwise fetch all non-retired patients. Returns a `200 OK` status with the patientIdentifierType response. If the user is not logged in a `401 Unauthorized` status is returned.
+### List patientIdentifierType
 
 ```console
 GET /patientidentifiertype
 ```
+    Fetch all non-retired patientIdentifierTypes resources that match any specified parameters otherwise fetch all non-retired patients. Returns a `200 OK` status with the patientIdentifierType response. If the user is not logged in a `401 Unauthorized` status is returned.
 
-* ### Get patientIdentifierType by UUID.
 
-    Retrieve a patientIdentifierType by its UUID. Returns a `404 Not Found` status if patientIdentifierType does not exist in the system. If the user is not logged in to perform this action, a `401 Unauthorized` status is returned.
+### Get patientIdentifierType by UUID.
 
 ```console
 GET /patientidentifiertype/:target_patientIdentifierType_uuid
 ```
+    Retrieve a patientIdentifierType by its UUID. Returns a `404 Not Found` status if patientIdentifierType does not exist in the system. If the user is not logged in to perform this action, a `401 Unauthorized` status is returned.
+
+
 ## Create a patientIdentifierType
 
+```console
+POST /patientidentifiertype
+{
+    "name": "Wilson Hosp MRN",
+    "description": "Wilson Hospital Medical Record Number",
+    "format": "\d{1,10}-\d",
+    "formatDescription": "Up to ten digts followed by a hyphen and another digit",
+    "required": true,
+    "validator": "org.openmrs.patient.impl.LuhnIdentifierValidator",
+    "checkDigit": true,
+    "locationBehavior": "REQUIRED",
+    "uniquenessBehavior": "Unique"
+}
+```
 * To create a patientIdentifierType you need to specify the below properties in the request. If you are not logged in to perform this action, a `401 Unauthorized` status is returned.
 
 ### Properties
@@ -59,24 +74,8 @@ Parameter | Type | Description
 *locationBehavior* | "REQUIRED" or "NOT USED" | behavior of the location with respect to the identifier 
 *uniquenessBehavior* | string | specify the uniqueness of the behaviour, it can be either Unique, Non Unique or Location.
 
-```console
-POST /patientidentifiertype
-{
-    "name": "Wilson Hosp MRN",
-    "description": "Wilson Hospital Medical Record Number",
-    "format": "\d{1,10}-\d",
-    "formatDescription": "Up to ten digts followed by a hyphen and another digit",
-    "required": true,
-    "validator": "org.openmrs.patient.impl.LuhnIdentifierValidator",
-    "checkDigit": true,
-    "locationBehavior": "REQUIRED",
-    "uniquenessBehavior": "Unique"
-}
-```
-## Update a patientIdentifierType
 
-* Update a target patientIdentifierType with given UUID, this method only modifies properties in the request. 
-Returns a `404 Not Found` status if patientIdentifierType not exists. If user not logged in to perform this action, a `401 Unauthorized status returned`.
+## Update a patientIdentifierType
 
 ```console
 POST /patientidentifertype/:target_patientidentifiertype_uuid
@@ -91,9 +90,16 @@ POST /patientidentifertype/:target_patientidentifiertype_uuid
     "uniquenessBehavior": "UNIQUE"
 }
 ```
+* Update a target patientIdentifierType with given UUID, this method only modifies properties in the request. 
+Returns a `404 Not Found` status if patientIdentifierType not exists. If user not logged in to perform this action, a `401 Unauthorized status returned`.
+
+
 
 ## Delete a patientIdentifierType
 
+```console
+DELETE /patientidentifiertype/:target_patientidentifiertype_uuid?purge=true
+```
 * Delete or retire a target patientIdentifierType by its UUID. Returns a `404 Not Found` status if patientIdentifierType not exists. If user is not logged in to perform this action, a `401 Unauthorized` status returned.
 
     ### Query Parameters
@@ -102,6 +108,3 @@ POST /patientidentifertype/:target_patientidentifiertype_uuid
     --- | --- | ---
     *purge* | `Boolean` | The resource will be retired unless purge = 'true'
 
-```console
-DELETE /patientidentifiertype/:target_patientidentifiertype_uuid?purge=true
-```

--- a/source/includes/Patient/patients.md
+++ b/source/includes/Patient/patients.md
@@ -36,11 +36,17 @@ Anyone who has an Encounter or who is enrolled in a Program is a Patient.)
 
 ## Search patients
 
-* ### Search patients
+### Search patients
+
+```console
+GET /patient?
+country=india
+&gender=M
+```
 
     Fetch all non-retired patients that match any specified parameters otherwise fetch all non-retired patients. Returns a `200 OK` status with the patient response. 
 
-    ### Query Parameters
+### Query Parameters
 
     Parameter | Description
     --- | ---
@@ -56,30 +62,17 @@ Anyone who has an Encounter or who is enrolled in a Program is a Patient.)
     givenname  | must be used with matchSimilar
     state | must be used with matchSimilar
 
-```console
-GET /patient?
-country=india
-&gender=M
-```
 
-* ### List patient by UUID.
-
-    Retrieve a patient by its UUID. Returns a `404 Not Found` status if patient does not exist in the system. If the user is not logged in to perform this action, a `401 Unauthorized` status is returned.
+### List patient by UUID.
 
 ```console
 GET /patient/:target_patient_uuid
 ```
 
+    Retrieve a patient by its UUID. Returns a `404 Not Found` status if patient does not exist in the system. If the user is not logged in to perform this action, a `401 Unauthorized` status is returned.
+
+
 ## Create a patient
-
-* To create a patient you need to specify the below properties in the request. If you are not logged in to perform this action, a `401 Unauthorized` status is returned.
-
-    ### Properties
-
-    Parameter | Type | Description
-    --- | --- | ---
-    *person* | `PERSON_UUID` | Person resource UUID
-    *identifiers* | `Array[]: Identifiers` | List of patientIdentifiers
 
 ```console
 POST /patient
@@ -95,7 +88,22 @@ POST /patient
     ]
 }
 ```
+
+* To create a patient you need to specify the below properties in the request. If you are not logged in to perform this action, a `401 Unauthorized` status is returned.
+
+    ### Properties
+
+    Parameter | Type | Description
+    --- | --- | ---
+    *person* | `PERSON_UUID` | Person resource UUID
+    *identifiers* | `Array[]: Identifiers` | List of patientIdentifiers
+
 ## Update a patient
+
+```console
+    POST /patient/:target_patient_uuid
+    -d modified_patient_object
+```
 
 * Update a target patient with given UUID, this method only modifies properties in the request. 
 Returns a `404 Not Found` status if patient not exists. If the user is not logged in to perform this action, a `401 Unauthorized status returned`.
@@ -112,12 +120,12 @@ Returns a `404 Not Found` status if patient not exists. If the user is not logge
     --- | --- | ---
     *resource* | `Patient` | Patient resource with updated properties
 
-```console
-    POST /patient/:target_patient_uuid
-    -d modified_patient_object
-```
 
 ## Delete a patient
+
+```console
+DELETE /patient/:target_patient_uuid?purge=true
+```
 
 * Delete or retire a target patient by its UUID. Returns a `404 Not Found` status if patient not exists. If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
 
@@ -128,26 +136,35 @@ Returns a `404 Not Found` status if patient not exists. If the user is not logge
     **uuid** | `String` | uuid to delete
     *purge* | `Boolean` | The resource will be voided/retired unless purge = 'true'
 
-```console
-DELETE /patient/:target_patient_uuid?purge=true
-```
 ## List patientIdentifier sub resources
 
 * ### List all patientIdentifier sub resources for a patient.
 
-    Retrieve all <b>identifier</b> sub resources of a <b>patient</b> resource by `target_patient_uuid`.Returns a `404 Not Found` status if patientIdentifier not exists. If user not logged in to perform this action, a `401 unauthorized` status returned.
-
 ```console
 GET /patient/:target_patient_uuid/identifier
 ```  
-* ### List patientIdentifier sub resource by it's UUID and parent patient UUID.
 
-    Retrieve a <b>patientIdentifier</b> sub resources of a <b>patient</b> resource. Returns a `404 Not Found` status if patientIdentifier not exists. If you are not logged in to perform this action, a `401 Unauthorized` status returned. 
+    Retrieve all <b>identifier</b> sub resources of a <b>patient</b> resource by `target_patient_uuid`.Returns a `404 Not Found` status if patientIdentifier not exists. If user not logged in to perform this action, a `401 unauthorized` status returned.
+
+* ### List patientIdentifier sub resource by it's UUID and parent patient UUID.
 
 ```console
 GET /patient/:target_patient_uuid/identifier/:target_identifier_uuid
 ```
+
+    Retrieve a <b>patientIdentifier</b> sub resources of a <b>patient</b> resource. Returns a `404 Not Found` status if patientIdentifier not exists. If you are not logged in to perform this action, a `401 Unauthorized` status returned. 
+
 ## Create a patientIdentifier sub resource with properties 
+
+```console
+POST patient/:target_patient_uuid/identifier
+{ 
+    "identifier" : "string",
+    "identifierType" : "target_identifer_uuid",
+    "location" : "target_location_uuid",
+    "preferred" : true/false
+}
+```
 
 * To create a patientIdentifier subresource for a specific patient resource you need to specify below properties in your request body.
 If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
@@ -166,16 +183,17 @@ If the user is not logged in to perform this action, a `401 Unauthorized` status
     *location* | `Location UUID` | Get patients for this location
     *preferred* | `boolean` | preferred/not preferred identifier
 
+## Update patientIdentifier sub resource with properties
+
 ```console
-POST patient/:target_patient_uuid/identifier
+POST patient/:target_patient_uuid/identifier/:target_identifier_uuid
 { 
-    "identifier" : "string",
-    "identifierType" : "target_identifer_uuid",
-    "location" : "target_location_uuid",
-    "preferred" : true/false
+"identifier" : "string",
+"identifierType" : "target_identifer_uuid",
+"location" : "target_location_uuid",
+"preferred" : true/false
 }
 ```
-## Update patientIdentifier sub resource with properties
 
 * Updates an patientIdentifier subresource value with given UUID, this method will only modify value of the subresource. Returns a `404 Not Found` status if attribute not exists. If user not logged in to perform this action, a `401 Unauthorized` status
 returned.
@@ -189,17 +207,12 @@ returned.
     *location* | `Location UUID` | updated location
     *preferred* | `boolean` | updated status of preferred/not preferred identifier
 
-```console
-POST patient/:target_patient_uuid/identifier/:target_identifier_uuid
-{ 
-"identifier" : "string",
-"identifierType" : "target_identifer_uuid",
-"location" : "target_location_uuid",
-"preferred" : true/false
-}
-```
 
 ## Delete patientIdentifier sub resource with properties
+
+```console
+DELETE /patient/:target_patient_uuid/identifier/:target_identifier_uuid
+```
 
 * Delete or retire a target identifier subresource by its UUID. Returns a `404 Not Found` status if attribute not exists. 
 If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
@@ -210,38 +223,17 @@ If the user is not logged in to perform this action, a `401 Unauthorized` status
     --- | --- | ---
     *purge* | `Boolean` | The resource will be voided/retired unless purge = ‘true’
     
-```console
-DELETE /patient/:target_patient_uuid/identifier/:target_identifier_uuid
-```
 
 ## List allergy subresources
-
-* List allergy subresource by its UUID and parent patient UUID.
-
-    Retrieve a <b>allergy</b> sub resources of a <b>patient</b> resource. Returns a `404 Not Found` status if allergy not exists. If you are not logged in to perform this action, a `401 Unauthorized` status returned. 
 
 ```console
 GET /patient/:target_patient_uuid/allergy/:target_allergy_uuid
 ```
+* List allergy subresource by its UUID and parent patient UUID.
+
+    Retrieve a <b>allergy</b> sub resources of a <b>patient</b> resource. Returns a `404 Not Found` status if allergy not exists. If you are not logged in to perform this action, a `401 Unauthorized` status returned. 
+
 ## Create a allergy sub resource with properties 
-
-* To create an allergy subresource for a specific patient resource, you need to specify below properties in your request body.
-If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
-
-    ### Query parameter 
-    Parameter | Description
-    --- | ---
-    `target_patient_uuid` | patient resource uuid
-
-    ### Properties for resource
-
-    Parameter | type | Description
-    --- | --- | ---
-    *allergen* | `String` | value of the allergen
-    *severity* | `Severity_UUID` | Severity uuid
-    *comment* | `String` | comment for the allergy
-    *allergy* | `allergy_UUID` | allergy uuid
-    *reaction* | `reaction_UUID` | reaction uuid
 
 ```console
 POST patient/:target_patient_uuid/allergy
@@ -263,18 +255,13 @@ POST patient/:target_patient_uuid/allergy
 ]
 }
 ```
-
-## Update allergy sub resource with properties
-
-* Updates an allergy subresource value with given UUID, this method will only modify value of the subresource. Returns a `404 Not Found` status if property not exists. If user not logged in to perform this action, a `401 Unauthorized` status
-returned.
+* To create an allergy subresource for a specific patient resource, you need to specify below properties in your request body.
+If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
 
     ### Query parameter 
-    
     Parameter | Description
     --- | ---
     `target_patient_uuid` | patient resource uuid
-    `target_allergy_uuid` | allergy resource uuid
 
     ### Properties for resource
 
@@ -285,6 +272,9 @@ returned.
     *comment* | `String` | comment for the allergy
     *allergy* | `allergy_UUID` | allergy uuid
     *reaction* | `reaction_UUID` | reaction uuid
+
+
+## Update allergy sub resource with properties
 
 ```console
 POST patient/:target_patient_uuid/allergy/:target_allergy_uuid
@@ -306,9 +296,32 @@ POST patient/:target_patient_uuid/allergy/:target_allergy_uuid
 ]
 }
 ```
+* Updates an allergy subresource value with given UUID, this method will only modify value of the subresource. Returns a `404 Not Found` status if property not exists. If user not logged in to perform this action, a `401 Unauthorized` status
+returned.
+
+    ### Query parameter 
+    
+    Parameter | Description
+    --- | ---
+    `target_patient_uuid` | patient resource uuid
+    `target_allergy_uuid` | allergy resource uuid
+
+    ### Properties for resource
+
+    Parameter | type | Description
+    --- | --- | ---
+    *allergen* | `String` | value of the allergen
+    *severity* | `Severity_UUID` | Severity uuid
+    *comment* | `String` | comment for the allergy
+    *allergy* | `allergy_UUID` | allergy uuid
+    *reaction* | `reaction_UUID` | reaction uuid
+
 
 ## Delete allergy sub resource with properties
 
+```console
+DELETE /patient/:target_patient_uuid/allergy/:target_allergy_uuid
+```
 * Delete or retire a target allergy subresource by its UUID. Returns a `404 Not Found` status if attribute not exists. 
 If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
 
@@ -318,6 +331,3 @@ If the user is not logged in to perform this action, a `401 Unauthorized` status
     --- | --- | ---
     *purge* | `Boolean` | The resource will be voided/retired unless purge = ‘true’
     
-```console
-DELETE /patient/:target_patient_uuid/allergy/:target_allergy_uuid
-```

--- a/source/includes/Person/person_attribute_type.md
+++ b/source/includes/Person/person_attribute_type.md
@@ -16,45 +16,30 @@
 
 ## List person attribute types
 
-* ### List all non-retired person attribute types.
+### List all non-retired person attribute types.
 
+```console
+GET /personattributetype?q=race
+```
     Quickly filter person attribute types with a given search query. If the request is not authenticated or the authenticated user does not have appropriate permissions, a `401 Unauthorized` status is returned.
 
-    #### Query Parameters
+    ### Query Parameters
 
     Parameter | Type | Description
     --- | --- | ---
     *q* | `Search Query` | Query to filter person attributes by its name(partial search is not supported)
 
-```console
-GET /personattributetype?q=race
- ```
 
-* ### Get person attribute type by UUID.
-
-    Retrieve a person attribute type by its UUID. Returns a `404 Not Found` status if the person attribute type does not exist. If the
-    user not logged in to perform this action, a `401 Unauthorized` status is returned.
+### Get person attribute type by UUID.
 
 ```console
 GET /personattributetype/:target_person_attribute_type_uuid
 ```
+    Retrieve a person attribute type by its UUID. Returns a `404 Not Found` status if the person attribute type does not exist. If the
+    user not logged in to perform this action, a `401 Unauthorized` status is returned.
+
 
 ## Create a person attribute type
-
-* To Create a person attribute type you need to specify below attributes in the request body. If the user is not logged in to perform this action,
- a `401 Unauthorized` status is returned.
-
-    ### Attributes
-
-    Parameter | Type | Description
-    --- | --- | ---
-    *name* | `String` | Name of the person attribute type (Required)
-    *description* | `String` | Description (Required)
-    *format* | `Java Class` | the Java class the PersonAttributeType  
-    *foreignKey* | `Number` | the internal identifier (foreign key) to a Concept that defines the possible values for this attribute
-    *sortWeight* | `Number` | the order this PersonAttributeType will appear in when searched
-    *searchable* | `Boolean` | true if this person attributes should be used to find patients. The default is false
-    *editPrivilege* | `JSON Object` | the privilege required to make changes to this type
 
 ```console
 POST /personattributetype
@@ -70,10 +55,10 @@ POST /personattributetype
     }
 }
 ```
-## Update a person attribute type
+* To Create a person attribute type you need to specify below attributes in the request body. If the user is not logged in to perform this action,
+ a `401 Unauthorized` status is returned.
 
-*  Update a target person attribute type with given UUID, this method only modifies properties in the request. Returns a `404 Not Found`
-status if the person attribute does not exist. If the user is not logged in to perform this action, a `401 Unauthorized` status is returned.
+    ### Attributes
 
     Parameter | Type | Description
     --- | --- | ---
@@ -84,6 +69,9 @@ status if the person attribute does not exist. If the user is not logged in to p
     *sortWeight* | `Number` | the order this PersonAttributeType will appear in when searched
     *searchable* | `Boolean` | true if this person attributes should be used to find patients. The default is false
     *editPrivilege* | `JSON Object` | the privilege required to make changes to this type
+
+
+## Update a person attribute type
 
 ```console
 POST /personattributetype
@@ -100,7 +88,25 @@ POST /personattributetype
 }
 ```
 
+*  Update a target person attribute type with given UUID, this method only modifies properties in the request. Returns a `404 Not Found`
+status if the person attribute does not exist. If the user is not logged in to perform this action, a `401 Unauthorized` status is returned.
+
+    Parameter | Type | Description
+    --- | --- | ---
+    *name* | `String` | Name of the person attribute type (Required)
+    *description* | `String` | Description (Required)
+    *format* | `Java Class` | the Java class the PersonAttributeType  
+    *foreignKey* | `Number` | the internal identifier (foreign key) to a Concept that defines the possible values for this attribute
+    *sortWeight* | `Number` | the order this PersonAttributeType will appear in when searched
+    *searchable* | `Boolean` | true if this person attributes should be used to find patients. The default is false
+    *editPrivilege* | `JSON Object` | the privilege required to make changes to this type
+
+
 ## Delete a person attribute type
+
+```console
+DELETE /personattributetype/:target_person_attribute_type_uuid?purge=true
+```
 
 * Delete or Retire a person attribute type by its UUID. Returns a `404 Not Found` status if the person attribute type does not exist. If the user is not logged in to perform this action, a `401 Unauthorized` status is returned.
 
@@ -110,6 +116,3 @@ POST /personattributetype
     --- | --- | ---
     *purge* | `Boolean` | The resource will be retired unless purge = ‘true’.Purging will attempt to remove the attribute type from the system irreversibly. Attribute types that have been used (i.e., are referenced from existing data) cannot be purged.
 
-```console
-DELETE /personattributetype/:target_person_attribute_type_uuid?purge=true
-```

--- a/source/includes/Person/persons.md
+++ b/source/includes/Person/persons.md
@@ -42,49 +42,32 @@ Person Attributes are suitable for storing other information. But historical val
 
 ## Search Persons
 
-* ### Search Persons
+### Search Persons
+
+```console
+GET /person?q=john
+```
      
      Fetch all non-voided persons that match the search query parameter. Returns a `200 OK` status with the Person response.
 
-    ### Parameters
+### Parameters
 
     Parameter | Type | Description
     --- | --- | ---
     *q* | *string* | *search by name*
 
-```console
-GET /person?q=john
-```
 
-* ### List person by UUID
-
-    Retrieve a person by their UUID. Returns a `404 Not Found` status if the person does not exist in the system. If the user is not logged in to perform this action, a `401 Unauthorized` status is returned.
+### List person by UUID
 
 ```console
 GET /person/:target_person_uuid
 ```
 
+    Retrieve a person by their UUID. Returns a `404 Not Found` status if the person does not exist in the system. If the user is not logged in to perform this action, a `401 Unauthorized` status is returned.
+
+
 ## Create a person
 
-* To create a person you need to specify the below properties in the request. `401 Unauthorized` is returned if the request is not authenticated or if the authenticated user does not have appropriate permissions.
-
-    ### Attributes
-
-    Parameter | Type | Description
-    --- | --- | ---
-    *names* | `Array[] : names` | List of names
-    *gender* | String | The patient's gender ("M" for male, "F" for female, or "U" for unknown)
-    *age* | Integer | The estimated age in years. Used when birthdate is unknown.
-    *birthDate* | String | Date of birth of a person
-    *birthDateEstimated* | Boolean | True if the birthdate is estimated; false if birthdate is accurate.
-    *birthTime* | String | The time of birth of the person
-    *dead* | Boolean | True if the patient is dead.
-    *deathDate* | String | Date of death of the person
-    *causeOfDeath* | `Concept UUID` | Reason for the death of the person
-    *deathdateEstimated* | Boolean | `true` if deathDate is estimate; `false` if deathDate is accurate
-    *addresses* | `Array[] : addresses` | The address details aggregated in an array
-    *attributes* | `Array[] : attributes` | The attribute details aggregated in an array
-    
 ```
 POST /person
 {
@@ -107,12 +90,28 @@ POST /person
 }
 ```
 
+
+* To create a person you need to specify the below properties in the request. `401 Unauthorized` is returned if the request is not authenticated or if the authenticated user does not have appropriate permissions.
+
+    ### Attributes
+
+    Parameter | Type | Description
+    --- | --- | ---
+    *names* | `Array[] : names` | List of names
+    *gender* | String | The patient's gender ("M" for male, "F" for female, or "U" for unknown)
+    *age* | Integer | The estimated age in years. Used when birthdate is unknown.
+    *birthDate* | String | Date of birth of a person
+    *birthDateEstimated* | Boolean | True if the birthdate is estimated; false if birthdate is accurate.
+    *birthTime* | String | The time of birth of the person
+    *dead* | Boolean | True if the patient is dead.
+    *deathDate* | String | Date of death of the person
+    *causeOfDeath* | `Concept UUID` | Reason for the death of the person
+    *deathdateEstimated* | Boolean | `true` if deathDate is estimate; `false` if deathDate is accurate
+    *addresses* | `Array[] : addresses` | The address details aggregated in an array
+    *attributes* | `Array[] : attributes` | The attribute details aggregated in an array
+    
+
 ## Update a person
-
-* Update a person. This method only modifies properties specified in the request. Returns a `404 Not found`.
-If not authenticated or authenticated user does not have sufficient privileges, `401 Unauthorized` status is returned.
-
-    An example of the request is as follows : 
 
 ```console
 POST /person/:target_person_uuid
@@ -122,7 +121,16 @@ POST /person/:target_person_uuid
 }
 ```
 
+* Update a person. This method only modifies properties specified in the request. Returns a `404 Not found`.
+If not authenticated or authenticated user does not have sufficient privileges, `401 Unauthorized` status is returned.
+
+    An example of the request is as follows : 
+
 ## Delete a person
+
+```console
+DELETE /person/:target_person_uuid?purge=true
+```
 
 * Delete or Void a target person. Returns a `404 Not Found` status if person not exists. If not authenticated or authenticated user does not have sufficient privileges, `401 Unauthorized` status is returned.
 
@@ -132,30 +140,36 @@ POST /person/:target_person_uuid
     --- | --- | ---
     *purge* | `Boolean` | The resource will be voided unless purge = ‘true’
 
-```console
-DELETE /person/:target_person_uuid?purge=true
- ```
 
 
 ## List person name subresource
 
-* List all the person name subresource corresponding to a `target_person_uuid`. Returns `404 Not Found` status if the person does not exist. 
-If not authenticated or authenticated user does not have sufficient privileges, a `401 Unauthorized` 
-status is returned.
-
 ```console
 GET /person/:target_person_uuid/name
 ```
-
-* List the person name by its `UUID` and corresponding to a `target_person_uuid`. Returns `404 Not Found` status if the person does not exist. 
+* List all the person name subresource corresponding to a `target_person_uuid`. Returns `404 Not Found` status if the person does not exist. 
 If not authenticated or authenticated user does not have sufficient privileges, a `401 Unauthorized` 
 status is returned.
 
 ```console
 GET /person/:target_person_uuid/name/:target_name_uuid
 ```
+* List the person name by its `UUID` and corresponding to a `target_person_uuid`. Returns `404 Not Found` status if the person does not exist. 
+If not authenticated or authenticated user does not have sufficient privileges, a `401 Unauthorized` 
+status is returned.
+
 
 ## Create person name subresource
+
+```console
+POST person/:target_person_uuid/name
+{ 
+    "givenName": "Mohit",
+    "familyName": "Kumar",
+    "preferred": true,
+    "prefix": "Mr."
+}
+```
 
 * To create a person name subresource for a specific person resource you need to specify below properties in your request body.
 If user not logged in to perform this action, a `401 Unauthorized` status is returned.
@@ -174,17 +188,17 @@ If user not logged in to perform this action, a `401 Unauthorized` status is ret
     *familyNameSuffix* | `String` | Suffix if any for the family name
     *degree* | `String` | degree attained by the person
 
+## Update person name subresource
+
 ```console
 POST person/:target_person_uuid/name
 { 
     "givenName": "Mohit",
-    "familyName": "Kumar",
+    "familyName": "Verma",
     "preferred": true,
-    "prefix": "Mr."
+    "prefix": "Dr."
 }
 ```
-
-## Update person name subresource
 
 * To update a person name with given UUID value for a specific person resource, you need to specify below properties in your request body.
 If user not logged in to perform this action, a `401 Unauthorized` status is returned.
@@ -203,40 +217,43 @@ If user not logged in to perform this action, a `401 Unauthorized` status is ret
     *familyNameSuffix* | `String` | Suffix if any for the family name
     *degree* | `String` | degree attained by the person
 
-```console
-POST person/:target_person_uuid/name
-{ 
-    "givenName": "Mohit",
-    "familyName": "Verma",
-    "preferred": true,
-    "prefix": "Dr."
-}
-```
 
 ## Delete person name subresource
+
+```console
+DELETE /person/:target_person_uuid/person/:target_name_uuid
+```
 
 * Delete or void a target name subresource. Returns a `404 Not Found` status if an attribute does not exist. 
 If the user is not logged in to perform this action, a `401 Unauthorized` status is returned.
 
- ```console
-DELETE /person/:target_person_uuid/person/:target_name_uuid
- ```
-
+ 
 ## List person address subresource
-
-* List all the person addresses corresponding to a `target_person_uuid`. Returns a `404 Not Found` status if person address does not exist. If the user is not logged in to perform this action, a `401 unauthorized` status is returned.
 
 ```console
 GET /person/:target_person_uuid/address
 ```
-
-* List all the person addresses by its `target_address_uuid` and corresponding to a `target_person_uuid`. Returns a `404 Not Found` status if person address does not exist. If user not logged in to perform this action, a `401 unauthorized` status is returned.
+* List all the person addresses corresponding to a `target_person_uuid`. Returns a `404 Not Found` status if person address does not exist. If the user is not logged in to perform this action, a `401 unauthorized` status is returned.
 
 ```console
 GET /person/:target_person_uuid/address/:target_address_uuid
 ```
+* List all the person addresses by its `target_address_uuid` and corresponding to a `target_person_uuid`. Returns a `404 Not Found` status if person address does not exist. If user not logged in to perform this action, a `401 unauthorized` status is returned.
+
 
 ## Create person address subresource
+
+```console
+POST person/:target_person_uuid/address
+{ 
+    "address1": "30, Vivekananda Layout, Munnekolal,Marathahalli",
+    "cityVillage": "Bengaluru"
+    "stateProvince": "Karnataka",
+    "postalCode": "560037",
+    "lattitude": "28.65033",
+    "longitude": "77.304255"
+}
+```
 
 * To create a person address subresource for a specific person resource you need to specify below properties in your request body.
 If user not logged in to perform this action, a `401 Unauthorized` status is returned.
@@ -263,6 +280,9 @@ If user not logged in to perform this action, a `401 Unauthorized` status is ret
     *longitude* | `String` | longitude of the address
 
 
+
+## Update person address subresource
+
 ```console
 POST person/:target_person_uuid/address
 { 
@@ -274,8 +294,6 @@ POST person/:target_person_uuid/address
     "longitude": "77.304255"
 }
 ```
-
-## Update person address subresource
 
 * To update a person address with given UUID value for a specific person resource you need to specify below properties in your request body.
 If user not logged in to perform this action, a `401 Unauthorized` status is returned.
@@ -302,44 +320,40 @@ If user not logged in to perform this action, a `401 Unauthorized` status is ret
     *longitude* | `String` | longitude of the address
 
 
-```console
-POST person/:target_person_uuid/address
-{ 
-    "address1": "30, Vivekananda Layout, Munnekolal,Marathahalli",
-    "cityVillage": "Bengaluru"
-    "stateProvince": "Karnataka",
-    "postalCode": "560037",
-    "lattitude": "28.65033",
-    "longitude": "77.304255"
-}
-```
-
 ## Delete a person address subresource
+
+```console
+DELETE /person/:target_person_uuid/person/:target_address_uuid
+```
 
 * Delete or void a target address subresource. Returns `404 Not Found` status if the person does not exist. 
 If not authenticated or authenticated user does not have sufficient privileges, a `401 Unauthorized` 
 status is returned.
 
- ```console
-DELETE /person/:target_person_uuid/person/:target_address_uuid
- ```
-
+ 
 ## List person attribute subresource
 
-* List all person attributes for a given person. Returns a `404 Not Found` if the person doesn't exist. If not authenticated or the authenticated user does not have sufficient privileges, a `401 Unauthorized` status is returned.
 
 ```console
 GET /person/:target_person_uuid/attribute
 ```
-
-* List all the person attributes by its `UUID` and corresponding to a `target_person_uuid`. Returns a `404 Not Found` status if person attribute does not exist. If user not logged in to perform this action, a `401 unauthorized` status is returned.
+* List all person attributes for a given person. Returns a `404 Not Found` if the person doesn't exist. If not authenticated or the authenticated user does not have sufficient privileges, a `401 Unauthorized` status is returned.
 
 ```console
 GET /person/:target_person_uuid/name/:target_attribute_uuid
 ```
+* List all the person attributes by its `UUID` and corresponding to a `target_person_uuid`. Returns a `404 Not Found` status if person attribute does not exist. If user not logged in to perform this action, a `401 unauthorized` status is returned.
+
 
 ## Create person attribute subresource
 
+```console
+POST person/:target_person_uuid/attribute
+{ 
+    "attributeType": "8d8718c2-c2cc-11de-8d13-0010c6dffd0f",
+    "value": "Birthplace",
+}
+```
 * To create a person attribute subresource for a specific person resource you need to specify below properties in your request body.
 If not authenticated or authenticated user does not have sufficient privileges, a `401 Unauthorized` 
 status is returned.
@@ -351,6 +365,9 @@ status is returned.
     *attributeType* | `UUID` | UUID of the attributeType
     *value* | `String` | value associated with the attribute
 
+
+## Update person attribute subresource
+
 ```console
 POST person/:target_person_uuid/attribute
 { 
@@ -358,9 +375,6 @@ POST person/:target_person_uuid/attribute
     "value": "Birthplace",
 }
 ```
-
-## Update person attribute subresource
-
 * To update a person attribute with given UUID value for a specific person resource you need to specify below properties in your request body.
 If not authenticated or authenticated user does not have sufficient privileges, a `401 Unauthorized` status is returned.
 
@@ -371,20 +385,14 @@ If not authenticated or authenticated user does not have sufficient privileges, 
     *attributeType* | `UUID` | UUID of the attributeType
     *value* | `String` | value associated with the attribute
 
-```console
-POST person/:target_person_uuid/attribute
-{ 
-    "attributeType": "8d8718c2-c2cc-11de-8d13-0010c6dffd0f",
-    "value": "Birthplace",
-}
-```
 
 ## Delete person attribute subresource
 
+```console
+DELETE /person/:target_person_uuid/person/:target_attribute_uuid
+```
 * Delete or void a target attribute. Returns `404 Not Found` status if the person does not exist. 
 If not authenticated or authenticated user does not have sufficient privileges, a `401 Unauthorized` 
 status is returned.
 
- ```console
-DELETE /person/:target_person_uuid/person/:target_attribute_uuid
- ```
+ 

--- a/source/includes/Provider/provider.md
+++ b/source/includes/Provider/provider.md
@@ -29,45 +29,33 @@ a social worker, or a lab tech. Generally speaking, any healthcare worker that a
 
 ## List providers
 
-* ### List all non-retired providers.
-    
+
+### List all non-retired providers.
+
+```console
+GET /provider?
+q=clerk
+```    
     Quickly filter providers with given query parameters.Returns a `404 Not Found` status if provider not exists. If user not logged 
     in to perform this action,a `401 Unauthorized` status returned.
     
-    ##### Query Parameters
+### Query Parameters
 
     Parameter | Type | Description
     --- | --- | ---
     *q* | `Search Query` | Get provider by name
     
-```console
-GET /provider?
-q=clerk
-  ```
     
-* ### Query provider by UUID.
+### Query provider by UUID.
 
-    Retrieve an provider by its UUID. Returns a `404 Not Found` status if provider not exists. If user not logged 
-    in to perform this action, a `401 Unauthorized` status returned.
-    
 ```console
 GET /provider/:target_provider_uuid
 ```
+    Retrieve an provider by its UUID. Returns a `404 Not Found` status if provider not exists. If user not logged 
+    in to perform this action, a `401 Unauthorized` status returned.
+    
    
 ## Create a provider
-
-* To Create an provider you need to specify below attributes in the request body.If you are not logged in to perform this action,
- a `401 Unauthorized` status returned.
-
-    ### Attributes
-
-    Parameter | Type | Description
-    --- | --- | ---
-    *person* | `Person UUID` | Target person who will be a provider for OpenMRS (required)
-    *identifier* | `String` | Value of the identifier.Identifier is used to virtually group providers in to groups (required)
-    *attributes* | `Array[]: Attribute` |  List of provider attributes 
-    *retired* | `Boolean` | Retired status for the provider.
-    
 
 ```console
 POST /provider
@@ -83,11 +71,9 @@ POST /provider
   "retired": false
 }
 ```
-## Update a provider
+* To Create an provider you need to specify below attributes in the request body.If you are not logged in to perform this action,
+ a `401 Unauthorized` status returned.
 
-*  Update a target provider with given UUID, this method only modifies properties in the request. Returns a `404 Not Found` 
-status if provider not exists. If user not logged in to perform this action, a `401 Unauthorized` status returned.
-    
     ### Attributes
 
     Parameter | Type | Description
@@ -97,6 +83,9 @@ status if provider not exists. If user not logged in to perform this action, a `
     *attributes* | `Array[]: Attribute` |  List of provider attributes 
     *retired* | `Boolean` | Retired status for the provider.
     
+
+## Update a provider
+
 ```console
 POST /provider/:target_provider_uuid
 {
@@ -111,9 +100,25 @@ POST /provider/:target_provider_uuid
   "retired": false
 }
 ```
+
+*  Update a target provider with given UUID, this method only modifies properties in the request. Returns a `404 Not Found` 
+status if provider not exists. If user not logged in to perform this action, a `401 Unauthorized` status returned.
+    
+    ### Attributes
+
+    Parameter | Type | Description
+    --- | --- | ---
+    *person* | `Person UUID` | Target person who will be a provider for OpenMRS (required)
+    *identifier* | `String` | Value of the identifier.Identifier is used to virtually group providers in to groups (required)
+    *attributes* | `Array[]: Attribute` |  List of provider attributes 
+    *retired* | `Boolean` | Retired status for the provider.
+    
     
 ## Delete a provider
 
+```console
+DELETE /provider/:target_provider_uuid?purge=true
+```
 * Delete or retire a target provider by its UUID. Returns a `404 Not Found` status if provider not exists.If user not logged 
   in to perform this action, a `401 Unauthorized` status returned.
 
@@ -123,34 +128,38 @@ POST /provider/:target_provider_uuid
     --- | --- | ---
     *purge* | `Boolean` | The resource will be retired unless purge = ‘true’
 
-```console
-DELETE /provider/:target_provider_uuid?purge=true
-```
 
 ## List provider attribute sub resources
 
-* ### List all provider attribute sub resources for a provider.
-
-    Retrieve all **provider attribute** sub resources of an  **provider** resource by target_provider_uuid. Returns a 
-    `404 Not Found` status if provider attribute not exists. If user not logged in to perform this action, a `401 Unauthorized` status
-    returned.
+### List all provider attribute sub resources for a provider.
 
 ```console
 GET /provider/:target_provider_uuid/attribute 
 ```
+    Retrieve all **provider attribute** sub resources of an  **provider** resource by target_provider_uuid. Returns a 
+    `404 Not Found` status if provider attribute not exists. If user not logged in to perform this action, a `401 Unauthorized` status
+    returned.
 
-* ### List provider attribute sub resources by it's UUID and parent provider UUID.
-    
+
+### List provider attribute sub resources by it's UUID and parent provider UUID.
+
+```console
+GET /provider/:target_provider_uuid/attribute/:target_provider_attribute_uuid
+```    
      Retrieve an **provider attribute** sub resources of a **provider** resource. Returns a `404 Not Found` status if provider 
      attribute not exists. If you are not logged in to perform this action, a `401 Unauthorized` status
      returned.
      
-```console
-GET /provider/:target_provider_uuid/attribute/:target_provider_attribute_uuid
-```
 
 ## Create a provider attribute sub resource with properties
 
+```console
+POST provider/:target_provider_uuid/attribute 
+{
+  "attributeType": "target_provider_attribute_type_uuid",
+  "value": "New provider"
+}
+```
 * To Create an attribute sub resource for a specific provider resource you need to specify below attributes in the request body.
 If user not logged in to perform this action, a `401 Unauthorized` status returned.
 
@@ -161,32 +170,7 @@ If user not logged in to perform this action, a `401 Unauthorized` status return
     *attributeType* | `Attribute_Type UUID` | Create Attribute from this Attribute_Type (required)
     *value* | `Depends on Attribute_Type Selected` | Value for the attribute (required)
 
-```console
-POST provider/:target_provider_uuid/attribute 
-{
-  "attributeType": "target_provider_attribute_type_uuid",
-  "value": "New provider"
-}
-```
 ## Update provider attribute sub resource
-
-* Updates an provider attribute sub resource value with given uuid, this method will only modify value of the sub resource. Returns 
-a `404 Not Found` status if provider attribute not exists. If user not logged in to perform this action, a `401 Unauthorized` status
-returned.
-
-    ### Query Parameters
-
-    Parameter | Type | Description
-    --- | --- | ---
-    *parent_uuid* | `Provider UUID` | Target provider resource UUID
-    *uuid* | `Provider_Attribute UUID` | Target provider attribute resource UUID
-
-    #### Attributes
-
-    Parameter | Type | Description
-    --- | --- | ---
-    *attributeType* | `Attribute_Type UUID` | Create Attribute from this Attribute_Type
-    *value* | `Depends on Attribute_Type Selected` | Value for the attribute
 
 ```console
 POST provider/:target_provider_uuid/attribute/:target_provider_attribute_uuid
@@ -195,9 +179,30 @@ POST provider/:target_provider_uuid/attribute/:target_provider_attribute_uuid
     "value": "New provider"
 }
 ```
+* Updates an provider attribute sub resource value with given uuid, this method will only modify value of the sub resource. Returns 
+a `404 Not Found` status if provider attribute not exists. If user not logged in to perform this action, a `401 Unauthorized` status
+returned.
+
+### Query Parameters
+
+    Parameter | Type | Description
+    --- | --- | ---
+    *parent_uuid* | `Provider UUID` | Target provider resource UUID
+    *uuid* | `Provider_Attribute UUID` | Target provider attribute resource UUID
+
+### Attributes
+
+    Parameter | Type | Description
+    --- | --- | ---
+    *attributeType* | `Attribute_Type UUID` | Create Attribute from this Attribute_Type
+    *value* | `Depends on Attribute_Type Selected` | Value for the attribute
+
 
 ## Delete provider attribute sub resource
 
+```console
+DELETE /provider/:target_provider_uuid/attribute/:target_provider_attribute_uuid
+```
 * Delete or Retire a target provider attribute sub resource by its UUID. Returns a `404 Not Found` status if attribute not exists. 
  If user not logged in to perform this action, a `401 Unauthorized` status returned.
 
@@ -207,6 +212,3 @@ POST provider/:target_provider_uuid/attribute/:target_provider_attribute_uuid
     --- | --- | ---
     *purge* | `Boolean` | The resource will be retired unless purge = ‘true’. Purging will attempt to irreversibly remove the provider attribute type from the system. Provider attribute types that have been used (i.e., are referenced from existing data) cannot be purged.
 
-```console
-DELETE /provider/:target_provider_uuid/attribute/:target_provider_attribute_uuid
-```

--- a/source/includes/Provider/provider_attribute_type.md
+++ b/source/includes/Provider/provider_attribute_type.md
@@ -14,32 +14,46 @@
 
 ## List provider attribute types
 
-* ### List all non-retired provider attribute types.
+### List all non-retired provider attribute types.
 
+```console
+GET /providerattributetype?q="Search Query"
+```
     Quickly filter provider attribute types with a given search query. Returns a `404 Not Found` status if the provider attribute type not exists.
     If user not authenticated or the authenticated user does not have appropriate permissions, a 401 Unauthorized status is returned.
 
-    #### Query Parameters
+### Query Parameters
 
     Parameter | Type | Description
     --- | --- | ---
     *q* | `Search Query` | Display Name of provider attribute type.
 
-```console
-GET /providerattributetype?q="Search Query"
- ```
 
-* ### List provider attribute type by UUID.
-
-    Retrieve a provider attribute type by its UUID. Returns a `404 Not Found` status if the provider attribute type not exists. 
-    If user not authenticated or the authenticated user does not have appropriate permissions, a 401 Unauthorized status is returned.
+### List provider attribute type by UUID.
 
 ```console
 GET /providerattributetype/:target_provider_attribute_type_uuid
 ```
+    Retrieve a provider attribute type by its UUID. Returns a `404 Not Found` status if the provider attribute type not exists. 
+    If user not authenticated or the authenticated user does not have appropriate permissions, a 401 Unauthorized status is returned.
+
 
 ## Create a provider attribute type
 
+
+```console
+POST /providerattributetype
+{
+  "name": "Provider Location",
+  "description": "This attribute type will record the loication of the provider",
+  "datatypeClassname": "org.openmrs.customdatatype.datatype.LongFreeTextDatatype",
+  "minOccurs": 0,
+  "maxOccurs": 1,
+  "datatypeConfig": "default",
+  "preferredHandlerClassname":   "org.openmrs.web.attribute.handler.LongFreeTextTextareaHandler",
+  "handlerConfig": "dafault"
+}
+```
 * To Create a provider attribute type you need to specify below attributes in the request body. If user not authenticated or 
 the authenticated user does not have appropriate permissions, a 401 Unauthorized status is returned.
 
@@ -56,22 +70,22 @@ the authenticated user does not have appropriate permissions, a 401 Unauthorized
     *datatypeConfig* | `String` | Provides ability to define custom data types configuration for openMRS
     *handlerConfig* | `String` | Allow handler to be used for more than one attribute type. The actual configuration depends on the needs of the specified handler. For example, a "Pre-defined List" handler could be made to implement a simple selection list and this configuration would tell the handler the possible choices in the list for this specific attribute type
 
+
+## Update a provider attribute type
+
 ```console
-POST /providerattributetype
+POST /providerattributetype/:target_provider_attribute_type_uuid
 {
   "name": "Provider Location",
   "description": "This attribute type will record the loication of the provider",
   "datatypeClassname": "org.openmrs.customdatatype.datatype.LongFreeTextDatatype",
   "minOccurs": 0,
-  "maxOccurs": 1,
+  "maxOccurs": 2,
   "datatypeConfig": "default",
   "preferredHandlerClassname": "org.openmrs.web.attribute.handler.LongFreeTextTextareaHandler",
   "handlerConfig": "dafault"
 }
 ```
-
-## Update a provider attribute type
-
 *  Update a target provider attribute type with given UUID, this method only modifies properties in the request. Returns a `404 Not Found`
 status if the provider attribute not exists. If user not authenticated or the authenticated user does not have appropriate permissions, 
 a 401 Unauthorized status is returned.
@@ -89,22 +103,12 @@ a 401 Unauthorized status is returned.
     *datatypeConfig* | `String` | Provides ability to define custom data types configuration for openMRS
     *handlerConfig* | `String` | Allow handler to be used for more than one attribute type. The actual configuration depends on the needs of the specified handler. For example, a "Pre-defined List" handler could be made to implement a simple selection list and this configuration would tell the handler the possible choices in the list for this specific attribute type
 
-```console
-POST /providerattributetype/:target_provider_attribute_type_uuid
-{
-  "name": "Provider Location",
-  "description": "This attribute type will record the loication of the provider",
-  "datatypeClassname": "org.openmrs.customdatatype.datatype.LongFreeTextDatatype",
-  "minOccurs": 0,
-  "maxOccurs": 2,
-  "datatypeConfig": "default",
-  "preferredHandlerClassname": "org.openmrs.web.attribute.handler.LongFreeTextTextareaHandler",
-  "handlerConfig": "dafault"
-}
-```
 
 ## Delete a provider attribute type
 
+```console
+DELETE /providerattributetype/:target_provider_attribute_type_uuid?purge=true
+```
 * Delete or Retire a provider attribute type by its UUID. Returns a `404 Not Found` status if the provider attribute type not
  exists. If user not authenticated or the authenticated user does not have appropriate permissions, a 401 Unauthorized status is returned.
 
@@ -114,6 +118,3 @@ POST /providerattributetype/:target_provider_attribute_type_uuid
     --- | --- | ---
     *purge* | `Boolean` | The resource will be retired unless purge = ‘true’.Purging will attempt to irreversibly remove the attribute type from the system. Attribute types that have been used (i.e., are referenced from existing data) cannot be purged.
 
-```console
-DELETE /providerattributetype/:target_provider_attribute_type_uuid?purge=true
-```

--- a/source/includes/User/privileges.md
+++ b/source/includes/User/privileges.md
@@ -14,21 +14,33 @@ A **Privilege** is an authorization to perform a particular action in the system
 
 ### List privilege
 
+```console
+    GET /privilege
+```
+
 * Fetch all privileges that match any specified parameters otherwise fetch all privileges. Returns a `200 OK` status with the privilege response. If not authenticated or authenticated user does not have sufficient privileges, a `401 Unauthorized` status is returned.
 
-    ```console
-    GET /privilege
-     ```
+    
 
 * #### Get privilege by UUID
 
+```console
+    GET /privilege/:target_privilege_uuid
+```
+
     Retrieve a privilege by its UUID. Returns a `404 Not Found` status if the privilege not exists. If not authenticated or authenticated user does not have sufficient privileges, a `401 Unauthorized` status is returned.
 
-    ```console
-    GET /privilege/:target_privilege_uuid
-    ```
+    
 
 ### Create a privilege
+
+```console
+        POST /privilege
+        {
+            "name": "Delete Patients",
+            "description": "A privilege or permission to delete patients"
+        }
+```
 
 * To create a privilege, you need to specify below attributes in the request body. If not authenticated or authenticated user does not have sufficient privileges, a `401 Unauthorized` status is returned.
 
@@ -39,15 +51,16 @@ A **Privilege** is an authorization to perform a particular action in the system
     *name* | `String` | Name of the privilege(Required)
     *description* | `String` | Description of the privilege(Required)
 
-    ```console
-        POST /privilege
-        {
-            "name": "Delete Patients",
-            "description": "A privilege or permission to delete patients"
-        }
-    ```
+    
 
 ### Update a privilege
+
+```console
+   POST /privilege/:target_privilege_uuid
+   {
+      "description": "A user who can delete all the encounter types"
+   }
+```
 
 * Update a privilege with given UUID, this method only modifies properties in the request. Returns a `404 Not Found`
 status, if the privilege does not exists. If not authenticated or authenticated user does not have sufficient privileges, a `401 Unauthorized` status is returned. Attempting to update a privilege's name will fail with the error code `400 Bad Request`.
@@ -58,14 +71,12 @@ status, if the privilege does not exists. If not authenticated or authenticated 
     --- | --- | ---
     *description* | `String` | Description of the privilege (Required)
 
-    ```console
-        POST /privilege/:target_privilege_uuid
-        {
-          "description": "A user who can delete all the encounter types"
-        }
-    ```
-
+    
 ### Delete a privilege
+
+```console
+   DELETE /privilege/:target_privilege_uuid?purge=true
+```
 
 * Delete a privilege by its UUID. Returns a `404 Not Found` status if the privilege not exists. If not authenticated or authenticated user does not have sufficient privileges, a `401 Unauthorized` 
 status is returned.
@@ -75,7 +86,3 @@ status is returned.
     Parameter | Type | Description
     --- | --- | ---
     *purge* | `Boolean` | `true` to delete the privilege from the system; if `false`, the request will have no effect
-
-    ```console
-        DELETE /privilege/:target_privilege_uuid?purge=true
-    ```

--- a/source/includes/User/role.md
+++ b/source/includes/User/role.md
@@ -14,33 +14,24 @@ A **Role** represents a group of privileges in the system. Roles may inherit pri
 
 ## List roles
 
-* Fetch all the roles that match any specified parameters otherwise fetch all roles. Returns a `200 OK` status with the role response. If the user is not logged in to perform this action, a `401 Unauthorized` status is returned.
-
 ```console
 GET /role
- ```
+```
+
+* Fetch all the roles that match any specified parameters otherwise fetch all roles. Returns a `200 OK` status with the role response. If the user is not logged in to perform this action, a `401 Unauthorized` status is returned.
+
 
 * ## Get a role by UUID.
-
-    Retrieve a role by its UUID. Returns a `404 Not Found` status if the role does not exist. If the
-    user is not logged in to perform this action, a `401 Unauthorized` status is returned.
 
 ```console
 GET /role/:target_role_uuid
 ```
 
+    Retrieve a role by its UUID. Returns a `404 Not Found` status if the role does not exist. If the
+    user is not logged in to perform this action, a `401 Unauthorized` status is returned.
+
+
 ## Create a role
-
-* To create a role, you need to specify below attributes in the request body. If the user is not logged in to perform this action, a `401 Unauthorized` status is returned.
-
-    ### Attributes
-
-    Parameter | Type | Description
-    --- | --- | ---
-    *name* | `String` | Name of the role (Required)
-    *description* | `String` | Description of the role (Required)
-    *privileges* | `Array[] : privileges` | An array of the privilege resource
-    *inheritedRoles* | `Array[] : inheritedRoles` | An array of the inheritedRoles type
 
 ```console
 POST /role
@@ -53,7 +44,27 @@ POST /role
   }]
 }
 ```
+
+* To create a role, you need to specify below attributes in the request body. If the user is not logged in to perform this action, a `401 Unauthorized` status is returned.
+
+    ### Attributes
+
+    Parameter | Type | Description
+    --- | --- | ---
+    *name* | `String` | Name of the role (Required)
+    *description* | `String` | Description of the role (Required)
+    *privileges* | `Array[] : privileges` | An array of the privilege resource
+    *inheritedRoles* | `Array[] : inheritedRoles` | An array of the inheritedRoles type
+
 ## Update a role
+
+```console
+POST /role
+{
+  "name": "Configures Forms",
+  "description": "Manages forms and attaches them to the UI"
+}
+```
 
 *  Update a role with given UUID, this method only modifies properties in the request. Returns a `404 Not Found` status if the role does not exist. If the user is not logged in to perform this action, a `401 Unauthorized` status is returned.
 
@@ -66,15 +77,12 @@ POST /role
     *privileges* | `Array[] : privileges` | An array of the privilege resource
     *inheritedRoles* | `Array[] : inheritedRoles` | An array of the inheritedRoles type
 
-```console
-POST /role
-{
-  "name": "Configures Forms",
-  "description": "Manages forms and attaches them to the UI"
-}
-```
 
 ## Delete a role
+
+```console
+DELETE /role/:target_role_uuid?purge=true
+```
 
 * Delete a role by its UUID. Returns a `404 Not Found` status if the role does not exist. If the user is not logged in to perform this action, a `401 Unauthorized` status is returned.
 
@@ -84,6 +92,3 @@ POST /role
     --- | --- | ---
     *purge* | `Boolean` | must be `true` to delete the role from the system; if `false`, the request will have no effect
 
-```console
-DELETE /role/:target_role_uuid?purge=true
-```

--- a/source/includes/User/user.md
+++ b/source/includes/User/user.md
@@ -17,6 +17,12 @@ The real-life person is represented by a Person record in OpenMRS, and a person 
 
 ### List all non-retired users.
 
+```console
+GET /user?
+q=user1
+```
+
+
   Quickly filter users with given query parameters. Returns a `404 Not Found` status if the user does not exist.
   If not logged in to perform this action, a `401 Unauthorized` status is returned.
   
@@ -27,37 +33,18 @@ The real-life person is represented by a Person record in OpenMRS, and a person 
 | --------- | -------------- | ------------------------------------- |
 | _q_       | `Search Query` | Filter users by username or system ID |
 
-```console
-GET /user?
-q=user1
-```
 
 ### Get user by UUID.
-
-  Retrieve a user by its UUID. Returns a `404 Not Found` status if the user does not exist. If not logged in to perform this action, a `401 Unauthorized` status is returned.
 
 ```console
 GET /user/:target_user_uuid
 ```
 
+
+  Retrieve a user by its UUID. Returns a `404 Not Found` status if the user does not exist. If not logged in to perform this action, a `401 Unauthorized` status is returned.
+
+
 ## Create a user
-
-- For convenience, the person's information can be included in order to create the corresponding person record at the same time as their user record. When creating a user record for an existing person, the existing person must only be referenced by UUID. If you are not logged in to perform this action,
-a `401 Unauthorized` status is returned.
-
-### Attributes
-
-Parameter | Type | Description
---- | --- | ---
-*name* | `String` | Name of the user
-*description* | `String | Description of the user
-*username* | `String | username of the user
-*password* | `String | password of the user
-*person* | `String` | person resource associated with the user
-*systemId* | `String` | a unique identifier assigned to each user
-*roles* | `Array[] : role` | a list of roles attributed to the user
-*userProperties* | `JSON Object`| A set of key value pairs. Used to store user specific data
-*secretQuestion* | `String` | A secret question chosen by the user
 
 ```console
 POST /user
@@ -91,24 +78,25 @@ POST /user
 }
 ```
 
-## Update a user
+- For convenience, the person's information can be included in order to create the corresponding person record at the same time as their user record. When creating a user record for an existing person, the existing person must only be referenced by UUID. If you are not logged in to perform this action,
+a `401 Unauthorized` status is returned.
 
-- Update a target user with given UUID, this method only modifies properties in the request. Returns a `404 Not Found`
-  status if the user does not exist. If not logged in to perform this action, a `401 Unauthorized` status is returned.
-    
 ### Attributes
 
-  Parameter | Type | Description
-  --- | --- | ---
-  *name* | `String` | Name of the user
-  *description* | `String | Description of the user
-  *username* | `String | username of the user
-  *password* | `String | password of the user
-  *person* | `String` | person resource associated with the user
-  *systemId* | `String` | a unique identifier assigned to each user
-  *roles* | `Array[] : role` | a list of roles attributed to the user
-  *userProperties* | `JSON Object`| A set of key value pairs. Used to store user specific data
-  *secretQuestion* | `String` | A secret question chosen by the user
+Parameter | Type | Description
+--- | --- | ---
+*name* | `String` | Name of the user
+*description* | `String | Description of the user
+*username* | `String | username of the user
+*password* | `String | password of the user
+*person* | `String` | person resource associated with the user
+*systemId* | `String` | a unique identifier assigned to each user
+*roles* | `Array[] : role` | a list of roles attributed to the user
+*userProperties* | `JSON Object`| A set of key value pairs. Used to store user specific data
+*secretQuestion* | `String` | A secret question chosen by the user
+
+
+## Update a user
 
 ```console
 POST /user/:target_user_uuid
@@ -142,7 +130,29 @@ POST /user/:target_user_uuid
 }
 ```
 
+- Update a target user with given UUID, this method only modifies properties in the request. Returns a `404 Not Found`
+  status if the user does not exist. If not logged in to perform this action, a `401 Unauthorized` status is returned.
+    
+### Attributes
+
+  Parameter | Type | Description
+  --- | --- | ---
+  *name* | `String` | Name of the user
+  *description* | `String | Description of the user
+  *username* | `String | username of the user
+  *password* | `String | password of the user
+  *person* | `String` | person resource associated with the user
+  *systemId* | `String` | a unique identifier assigned to each user
+  *roles* | `Array[] : role` | a list of roles attributed to the user
+  *userProperties* | `JSON Object`| A set of key value pairs. Used to store user specific data
+  *secretQuestion* | `String` | A secret question chosen by the user
+
+
 ## Delete a user
+
+```console
+DELETE /user/:target_user_uuid?purge=true
+```
 
 - Delete or retire a target user by its UUID. Returns a `404 Not Found` status if the user does not exist. If not logged in to perform this action, a `401 Unauthorized` status is returned.
 
@@ -152,6 +162,3 @@ POST /user/:target_user_uuid
 | --------- | --------- | ------------------------------------------------- |
 | _purge_   | `Boolean` | The resource will be voided unless purge = ‘true’ |
 
-```console
-DELETE /user/:target_user_uuid?purge=true
-```

--- a/source/includes/Visit/visit_attribute_type.md
+++ b/source/includes/Visit/visit_attribute_type.md
@@ -17,31 +17,46 @@
 
 ## List visits attribute types
 
-* ### List all non-retired visits attribute types.
-    
+### List all non-retired visits attribute types.
+
+```console
+GET /visitattributetype?q="Search Query"
+```
+  
     Quickly filter visit attribute types with a given search query. Returns a `404 Not Found` status if the visit attribute type not exists.
      If the user not logged in to  perform this action, a `401 Unauthorized` status returned.
     
-    ### Query Parameters
+### Query Parameters
 
     Parameter | Type | Description
     --- | --- | ---
     *q* | `Search Query` | Display Name of Visit attribute type.
 
-```console
-GET /visitattributetype?q="Search Query"
-  ```
     
-* ### List visit attribute type by UUID.
-
-    Retrieve a visit attribute type by its UUID. Returns a `404 Not Found` status if the visit attribute type not exists. If the 
-    user not logged in to  perform this action, a `401 Unauthorized` status returned.
+### List visit attribute type by UUID.
     
 ```console
 GET /visitattributetype/:target_visit_attribute_type_uuid
 ```
+
+    Retrieve a visit attribute type by its UUID. Returns a `404 Not Found` status if the visit attribute type not exists. If the 
+    user not logged in to  perform this action, a `401 Unauthorized` status returned.
    
 ## Create a visit attribute type
+
+```console
+POST /visitattributetype
+{
+  "name": "Patient condition",
+  "description": "This attribute type will record the health conditon of the patient",
+  "datatypeClassname": "org.openmrs.customdatatype.datatype.LongFreeTextDatatype",
+  "minOccurs": 0,
+  "maxOccurs": 1,
+  "datatypeConfig": "default",
+  "preferredHandlerClassname": "org.openmrs.web.attribute.handler.LongFreeTextTextareaHandler",
+  "handlerConfig": "dafault"
+}
+```
 
 * To Create a visit attribute type, you need to specify below attributes in the request body. If the user not logged in to perform this action,
  a `401 Unauthorized` status returned.
@@ -59,21 +74,22 @@ GET /visitattributetype/:target_visit_attribute_type_uuid
     *datatypeConfig* | `String` | Allow the data type have any name and config it wants/needs.
     *handlerConfig* | `String` | Allow the handler have any name and config it wants/needs. This will help to identify the data type unambiguously which has been contained and will allow introspecting
    
+
+## Update a visit attribute type
+
 ```console
-POST /visitattributetype
+POST /visitattributetype/:target_visit_attribute_type_uuid
 {
-  "name": "Patient condition",
+  "name": "Patient condition modified",
   "description": "This attribute type will record the health conditon of the patient",
   "datatypeClassname": "org.openmrs.customdatatype.datatype.LongFreeTextDatatype",
   "minOccurs": 0,
-  "maxOccurs": 1,
+  "maxOccurs": 2,
   "datatypeConfig": "default",
   "preferredHandlerClassname": "org.openmrs.web.attribute.handler.LongFreeTextTextareaHandler",
   "handlerConfig": "dafault"
 }
 ```
-## Update a visit attribute type
-
 *  Update a target visit attribute type with given UUID, this method only modifies properties in the request. Returns a `404 Not Found` 
 status if the visit attribute not exists. If the user not logged in to perform this action, a `401 Unauthorized` status returned.
 
@@ -96,21 +112,13 @@ status if the visit attribute not exists. If the user not logged in to perform t
     *datatypeConfig* | `String` | Allow the data type have any name and config it wants/needs.
     *handlerConfig* | `String` | Allow the handler have any name and config it wants/needs. This will help to identify the data type unambiguously which has been contained and will allow introspecting
     
-```console
-POST /visitattributetype/:target_visit_attribute_type_uuid
-{
-  "name": "Patient condition modified",
-  "description": "This attribute type will record the health conditon of the patient",
-  "datatypeClassname": "org.openmrs.customdatatype.datatype.LongFreeTextDatatype",
-  "minOccurs": 0,
-  "maxOccurs": 2,
-  "datatypeConfig": "default",
-  "preferredHandlerClassname": "org.openmrs.web.attribute.handler.LongFreeTextTextareaHandler",
-  "handlerConfig": "dafault"
-}
-```
+
     
 ## Delete a visit attribute type
+
+```console
+DELETE /visitattributetype/:target_visit_attribute_type_uuid?purge=true
+```
 
 * Delete or Retire a target visit attribute type by its UUID. Returns a `404 Not Found` status if the visit attribute type not exists. If the user not logged in to perform this action, a `401 Unauthorized` status returned.
 
@@ -120,6 +128,3 @@ POST /visitattributetype/:target_visit_attribute_type_uuid
     --- | --- | ---
     *purge* | `Boolean` | The resource will be voided/retired unless purge = ‘true’.Purging will attempt to remove the attribute type from the system irreversibly. Attribute types that have been used (i.e., are referenced from existing data) cannot be purged.
 
-```console
-DELETE /visitattributetype/:target_visit_attribute_type_uuid?purge=true
-```

--- a/source/includes/Visit/visit_type.md
+++ b/source/includes/Visit/visit_type.md
@@ -22,32 +22,41 @@
 
 
 ## List visits types
-* ### List all non-retired visits types.
-    
+
+### List all non-retired visits types.
+
+```console
+GET /visittype?q="Search Query"
+```
+  
     Quickly filter visit types with a given search query. Returns a `404 Not Found` status if visit type not exists. 
     If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
     
-    ##### Query Parameters
+### Query Parameters
 
     Parameter | Type | Description
     --- | --- | ---
     *q* | `Search Query` | Display Name of Visit Type.
 
-```console
-GET /visittype?q="Search Query"
-```
     
-* ### List visit type by UUID.
+### List visit type by UUID.
 
-    Retrieve a visit type by its UUID. Returns a `404 Not Found` status if visit type not exists. If user not logged 
-    in to perform this action, a `401 Unauthorized` status returned.
-    
 ```console
 GET /visittype/:target_visit_type_uuid
 ```
+    Retrieve a visit type by its UUID. Returns a `404 Not Found` status if visit type not exists. If user not logged 
+    in to perform this action, a `401 Unauthorized` status returned.
+    
    
 ## Create a visit type
 
+```console
+POST /visittype
+{
+    "name": "Name for the visit type",
+    "description": "Description for the visit type"
+}
+```
 * To Create a visit type, you need to specify below attributes in the request body. If you are not logged in to perform this action,
  a `401 Unauthorized` status returned.
 
@@ -58,15 +67,16 @@ GET /visittype/:target_visit_type_uuid
     *name* | `String` | Name of the visit type (Required)
     *description* | `Patient UUID` | Visit type resource UUID (Required)
    
-```console
-POST /visittype
-{
-    "name": "Name for the visit type",
-    "description": "Description for the visit type"
-}
-```
+
 ## Update a visit type
 
+```console
+POST /type/:target_visit_type_uuid
+{
+    "name": "Modified name for the visit type",
+    "description": "Modified description for the visit type"
+}
+```
 *  Update a target visit type with given UUID, this method only modifies properties in the request. Returns a `404 Not Found` 
 status if visit not exists. If user not logged in to perform this action, a `401 Unauthorized` status returned.
 
@@ -83,16 +93,12 @@ status if visit not exists. If user not logged in to perform this action, a `401
     *name* | `String` | Name of the visit type (Required)
     *description* | `Patient UUID` | Visit type resource UUID (Required)
     
-```console
-POST /type/:target_visit_type_uuid
-{
-    "name": "Modified name for the visit type",
-    "description": "Modified description for the visit type"
-}
-```
     
 ## Delete a visit type
 
+```console
+DELETE /visittype/:target_visit_type_uuid?purge=true
+```
 * Delete or Retire a target visit type by its UUID. Returns a `404 Not Found` status if visit not exists. If user not logged 
   in to perform this action, a `401 Unauthorized` status returned.
 
@@ -102,6 +108,3 @@ POST /type/:target_visit_type_uuid
     --- | --- | ---
     *purge* | `Boolean` | The resource will be voided/retired unless purge = ‘true’
 
-```console
-DELETE /visittype/:target_visit_type_uuid?purge=true
-```

--- a/source/includes/Visit/visits.md
+++ b/source/includes/Visit/visits.md
@@ -38,12 +38,20 @@ contain <b> three encounters (Registration, Consultation, and Dispensing) </b>.
 
 ## List visits
 
-* ### List all non-retired visits.
+```console
+GET /visit?
+includeInactive=true
+&fromStartDate=2016-10-08T04:09:23.000Z
+&patient=target_patient_uuid
+&location=target_location_uuid
+```
+
+### List all non-retired visits.
     
     Quickly filter visits with given query parameters. Returns a `404 Not Found` status if visit not exists. If user not logged 
     in to perform this action, a `401 Unauthorized` status returned.
     
-    ### Query Parameters
+### Query Parameters
 
     Parameter | Type | Description
     --- | --- | ---
@@ -52,41 +60,18 @@ contain <b> three encounters (Registration, Consultation, and Dispensing) </b>.
     *includeInactive* | `Boolean` | Active/Inactive status of visit
     *fromStartDate* | `Date (ISO8601 Long)` | Start date of the visit
 
-```console
-GET /visit?
-includeInactive=true
-&fromStartDate=2016-10-08T04:09:23.000Z
-&patient=target_patient_uuid
-&location=target_location_uuid
-```
     
-* ### List visit by UUID.
+### List visit by UUID.
 
-    Retrieve a visit by its UUID. Returns a `404 Not Found` status if visit not exists. If user not logged 
-    in to perform this action, a `401 Unauthorized` status returned.
-    
 ```console
 GET /visit/:target_visit_uuid
 ```
+    Retrieve a visit by its UUID. Returns a `404 Not Found` status if visit not exists. If user not logged 
+    in to perform this action, a `401 Unauthorized` status returned.
+    
    
 ## Create visit
 
-* To Create a visit you need to specify below attributes in the request body. If you are not logged in to perform this action,
- a `401 Unauthorized` status returned.
-
-    ### Attributes
-
-    Parameter | Type | Description
-    --- | --- | ---
-    *patient* | `Patient UUID` | Patient resource UUID
-    *visitType* | `Patient UUID` | Visit type resource UUID
-    *startDatetime* | `Date (ISO8601 Long)` | Start date of the visit
-    *location* | `Location UUID` | Location resource UUID 
-    *indication* | `string` | Any indication of the visit    
-    *stopDatetime* | `Date (ISO8601 Long)` | End date of the vist    
-    *encounters* | `Array[]: Encounter UUID` | Encounter resources UUID    
-    *attributes* | `Array[]: Attribute` | List of visit attributes  
-   
 ```console
 POST /visit
 {
@@ -106,8 +91,29 @@ POST /visit
     ]
 }
 ```
+* To Create a visit you need to specify below attributes in the request body. If you are not logged in to perform this action,
+ a `401 Unauthorized` status returned.
+
+    ### Attributes
+
+    Parameter | Type | Description
+    --- | --- | ---
+    *patient* | `Patient UUID` | Patient resource UUID
+    *visitType* | `Patient UUID` | Visit type resource UUID
+    *startDatetime* | `Date (ISO8601 Long)` | Start date of the visit
+    *location* | `Location UUID` | Location resource UUID 
+    *indication* | `string` | Any indication of the visit    
+    *stopDatetime* | `Date (ISO8601 Long)` | End date of the vist    
+    *encounters* | `Array[]: Encounter UUID` | Encounter resources UUID    
+    *attributes* | `Array[]: Attribute` | List of visit attributes  
+   
 ## Update visit
 
+
+```console
+POST /visit/:target_visit_uuid
+-d  modified_visit_object
+```
 *  Update a target visit with given UUID, this method only modifies properties in the request. Returns a `404 Not Found` 
 status if visit not exists. If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
 
@@ -123,13 +129,12 @@ status if visit not exists. If the user is not logged in to perform this action,
     --- | --- | ---
     *resource* | `Visit` | Visit resource with updated properties.
     
-```console
-POST /visit/:target_visit_uuid
--d  modified_visit_object
-```
     
 ## Delete visit
 
+```console
+DELETE /visit/:target_visit_uuid?purge=true
+```
 * Delete or Retire a target visit by its UUID. Returns a `404 Not Found` status if visit not exists. If the user is not logged 
   in to perform this action, a `401 Unauthorized` status returned.
 
@@ -139,32 +144,36 @@ POST /visit/:target_visit_uuid
     --- | --- | ---
     *purge* | `Boolean` | The resource will be voided/retired unless purge = ‘true’
 
-```console
-DELETE /visit/:target_visit_uuid?purge=true
-```
 ## List attribute sub resources
 
-* ### List all attribute subresources for a visit.
-
-    Retrieve all <b>attribute</b> sub resources of a  <b>visit</b> resource by target_visit_uuid.Returns a 
-    `404 Not Found` status if attribute not exists. If user not logged in to perform this action, a `401 Unauthorized` status
-    returned.
+### List all attribute subresources for a visit.
 
 ```console
 GET /visit/:target_visit_uuid/attribute 
 ```
 
-* ### List attribute subresources by it's UUID and parent visit UUID.
-    
-     Retrieve an <b>attribute</b> sub resources of a <b>visit</b> resource.Returns a 
-     `404 Not Found` status if attribute not exists. If you are not logged in to perform this action, a `401 Unauthorized` status
-     returned.
-     
+    Retrieve all <b>attribute</b> sub resources of a  <b>visit</b> resource by target_visit_uuid.Returns a 
+    `404 Not Found` status if attribute not exists. If user not logged in to perform this action, a `401 Unauthorized` status
+    returned.
+
+
+### List attribute subresources by it's UUID and parent visit UUID.
+
 ```console
 GET /visit/:target_visit_uuid/attribute/:target_attribute_uuid
-```
+```    
+Retrieve an <b>attribute</b> sub resources of a <b>visit</b> resource.Returns a `404 Not Found` status if attribute not exists. If you are not logged in to perform this action, a `401 Unauthorized` status is returned.
+     
 
 ## Create an attribute sub resource with properties
+
+```console
+POST visit/:target_visit_uuid/attribute 
+{
+    "attributeType": "target_attribute_type_uuid",
+    "value": "value_for_the_attriute"
+}
+```
 
 * To Create an attribute subresource for a specific visit resource, you need to specify below attributes in the request body.
 If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
@@ -176,17 +185,17 @@ If the user is not logged in to perform this action, a `401 Unauthorized` status
     *attributeType* | `Attribute_Type UUID` | Create Attribute from this Attribute_Type
     *value* | `Depends on Attribute_Type Selected` | Value for the attribute
     
-```console
-POST visit/:target_visit_uuid/attribute 
-{
-    "attributeType": "target_attribute_type_uuid",
-    "value": "value_for_the_attriute"
-}
-```
  
  
 ## Update attribute subresource
 
+```console
+POST visit/:target_visit_uuid/attribute/:target_attribute_uuid
+{
+    "attributeType": "target_attribute_type_uuid",
+    "value": "modified_attriute_value"
+} 
+```
 * Updates an attribute subresource value with given UUID, this method will only modify the value of the subresource. Returns a `404 Not Found` status if attribute not exists. If user not logged in to perform this action, a `401 Unauthorized` status
 returned.
 
@@ -197,15 +206,13 @@ returned.
     *attributeType* | `Attribute_Type UUID` | Attribute_Type resource UUID
     *updated value* | `Depends on Attribute_Type Selected` | Updated value for the attribute
 
-```console
-POST visit/:target_visit_uuid/attribute/:target_attribute_uuid
-{
-    "attributeType": "target_attribute_type_uuid",
-    "value": "modified_attriute_value"
-} 
-```
+
 ## Delete attribute sub resource
 
+
+```console
+DELETE /visit/:target_visit_uuid/attribute/:target_attribute_uuid
+```
 * Delete or Retire a target attribute subresource by its UUID. Returns a `404 Not Found` status if attribute not exists. 
 If the user is not logged in to perform this action, a `401 Unauthorized` status returned.
 
@@ -215,6 +222,3 @@ If the user is not logged in to perform this action, a `401 Unauthorized` status
     --- | --- | ---
     *purge* | `Boolean` | The resource will be voided/retired unless purge = ‘true’
     
-```console
-DELETE /visit/:target_visit_uuid/attribute/:target_attribute_uuid
-```

--- a/source/includes/auth.md
+++ b/source/includes/auth.md
@@ -10,8 +10,6 @@
 
 ## Retrieve session token
 
-The session token is retrieved using Basic authentication on the `/session` endpoint. The response will include a `JSESSIONID` in the header. This session ID is also included in the response object
-
 ```console
 GET /openmrs/ws/rest/v1/session 
   -H 'Authorization: Basic Auth <base64 encoded username:password'
@@ -28,6 +26,10 @@ Set-Cookie: JSESSIONID=FB0629C001449CE14DF1078ACDDBA858; Path=/openmrs; HttpOnly
 }
 ```
 
+
+The session token is retrieved using Basic authentication on the `/session` endpoint. The response will include a `JSESSIONID` in the header. This session ID is also included in the response object
+
+
 The `sessionId` token should be passed with all subsequent calls as a cookie named `JSESSIONID`.
 
 ## Logout User/End session
@@ -39,17 +41,19 @@ DELETE /openmrs/ws/rest/v1/session -H 'Accept: application/json'
 
 ## Changing Password
 
-<b>Since version 2.17 of the webservices.rest module:</b>
-
-* An administrator (with the `EDIT_USER_PASSWORDS` privilege) can change the password for other users by 
-  posting a new password to `/password/:target_user_uuid`.
-
 ```console
 POST /openmrs/ws/rest/v1/password/:target_user_uuid 
 {
   "newPassword" : "newPassword"
 }
 ``` 
+
+
+<b>Since version 2.17 of the webservices.rest module:</b>
+
+* An administrator (with the `EDIT_USER_PASSWORDS` privilege) can change the password for other users by 
+  posting a new password to `/password/:target_user_uuid`.
+
 
 * After authenticating user can change their own password, by posting to `/password`
 
@@ -63,9 +67,10 @@ POST /openmrs/ws/rest/v1/password
 
 ## Getting all location without authentication
 
-While fetching individual locations requires authentication, you can get a list of available locations by passing 
-the special `tag` "Login Location" as a query parameter.
-
 ```console
 GET /openmrs/ws/rest/v1/location?tag=Login+Location' 
 ```
+
+While fetching individual locations requires authentication, you can get a list of available locations by passing 
+the special `tag` "Login Location" as a query parameter.
+

--- a/source/includes/info.md
+++ b/source/includes/info.md
@@ -39,8 +39,6 @@ from OpenMRS
 
 # Schema
 
-All API access is over HTTPS, and can be accessed from `https://demo.openmrs.org/openmrs/ws/rest/v1`. All data is sent and received as JSON.
-
 ```console
 curl -X GET "https://demo.openmrs.org/openmrs/ws/rest/v1/concept"
 connection: keep-alive
@@ -51,6 +49,9 @@ etag: "04c83ff0cf2cc35cf05a2075ad117df83"
 server: nginx/1.10.3 (Ubuntu)
 strict-transport-security: max-age=15768000
 ```
+
+All API access is over HTTPS, and can be accessed from `https://demo.openmrs.org/openmrs/ws/rest/v1`. All data is sent and received as JSON.
+
 
 # Resources
 


### PR DESCRIPTION
1. As Burke had suggested to remove the redundant space on the left pane corresponding to the console samples on the right, I moved the console examples to the starting of each operation heading so that the space gets adjusted itself
2. now blank space is visible only if the samples are longer than their description.