### PR TITLE
Bump ruby from 2.4.0 to 3.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 language: ruby
 
 rvm:
-  - 2.4.0
+  - 3.0.1
 
 before_install:
   - gem update --system


### PR DESCRIPTION
Bump Travis ruby from 2.4.0 to 3.0.1 in order to solve the Travis build failed.